### PR TITLE
修复悬浮框难以点击

### DIFF
--- a/app/src/main/java/li/songe/gkd/debug/FloatingService.kt
+++ b/app/src/main/java/li/songe/gkd/debug/FloatingService.kt
@@ -40,13 +40,13 @@ class FloatingService : CompositionFbService({
             Icon(painter = painterResource(SafeR.ic_capture),
                 contentDescription = "capture",
                 modifier = Modifier
-                    .clickable(indication = null,
-                        interactionSource = remember { MutableInteractionSource() }) {
-                        appScope.launchTry(Dispatchers.IO) {
-                            SnapshotExt.captureSnapshot()
-                            ToastUtils.showShort("快照成功")
-                        }
-                    }
+//                    .clickable(indication = null,
+//                        interactionSource = remember { MutableInteractionSource() }) {
+//                        appScope.launchTry(Dispatchers.IO) {
+//                            SnapshotExt.captureSnapshot()
+//                            ToastUtils.showShort("快照成功")
+//                        }
+//                    }
                     .size(40.dp),
                 tint = Color.Red)
         }.enableCloseBubble(false).enableAnimateToEdge(false)

--- a/app/src/main/java/li/songe/gkd/debug/FloatingService.kt
+++ b/app/src/main/java/li/songe/gkd/debug/FloatingService.kt
@@ -25,8 +25,12 @@ import li.songe.gkd.notif.floatingChannel
 import li.songe.gkd.notif.floatingNotif
 import li.songe.gkd.util.SafeR
 import li.songe.gkd.util.launchTry
+import kotlin.math.abs
+
 
 class FloatingService : CompositionFbService({
+    var lastX = 0.0F
+    var lastY = 0.0F
     useLifeCycleLog()
     setupBubble { _, resolve ->
         val builder = FloatingBubble.Builder(this).bubble {
@@ -43,6 +47,19 @@ class FloatingService : CompositionFbService({
                     .size(40.dp),
                 tint = Color.Red)
         }.enableCloseBubble(false).enableAnimateToEdge(false)
+            .addFloatingBubbleListener(object : FloatingBubble.Listener {
+                override fun onUp(x: Float, y: Float) {
+                    appScope.launchTry(Dispatchers.IO) {
+                        ToastUtils.showShort("x:$x ,y:$y ,${abs((lastX - x) + (lastY - y))}")
+                        if (abs(((lastX - x) + lastY) - y) < 50) {
+                            SnapshotExt.captureSnapshot()
+                            ToastUtils.showShort("快照成功")
+                        }
+                        lastX = x
+                        lastY = y
+                    }
+                }   // ..., when finger release from bubble
+            })
         resolve(builder)
     }
 }) {

--- a/app/src/main/java/li/songe/gkd/debug/FloatingService.kt
+++ b/app/src/main/java/li/songe/gkd/debug/FloatingService.kt
@@ -25,7 +25,7 @@ import li.songe.gkd.notif.floatingChannel
 import li.songe.gkd.notif.floatingNotif
 import li.songe.gkd.util.SafeR
 import li.songe.gkd.util.launchTry
-import kotlin.math.abs
+import kotlin.math.sqrt
 
 
 class FloatingService : CompositionFbService({
@@ -50,15 +50,14 @@ class FloatingService : CompositionFbService({
             .addFloatingBubbleListener(object : FloatingBubble.Listener {
                 override fun onUp(x: Float, y: Float) {
                     appScope.launchTry(Dispatchers.IO) {
-                        ToastUtils.showShort("x:$x ,y:$y ,${abs((lastX - x) + (lastY - y))}")
-                        if (abs(((lastX - x) + lastY) - y) < 50) {
+                        if (sqrt((lastX - x) *(lastX - x) + (lastY - y)*(lastY - y)) < 50) { // 计算移动距离是否小于50像素
                             SnapshotExt.captureSnapshot()
                             ToastUtils.showShort("快照成功")
                         }
                         lastX = x
                         lastY = y
                     }
-                }   // ..., when finger release from bubble
+                }
             })
         resolve(builder)
     }


### PR DESCRIPTION
点击悬浮窗时可能触发移动事件而不是点击事件，于是可以通过判断悬浮窗的移动距离来判断是点击还是移动