### PR TITLE
feat: support long click action

### DIFF
--- a/app/src/main/java/li/songe/gkd/data/Rule.kt
+++ b/app/src/main/java/li/songe/gkd/data/Rule.kt
@@ -134,20 +134,20 @@ val clickNode: ActionFc = { _, node ->
     )
 }
 
-val clickCenter: ActionFc = { context, node ->
+fun getClickCenterAction(action: String, duration: Long): ActionFc = { context, node ->
     val react = Rect()
     node.getBoundsInScreen(react)
     val x = (react.right + react.left) / 2f
     val y = (react.bottom + react.top) / 2f
     ActionResult(
-        action = "clickCenter",
+        action = action,
         result = if (0 <= x && 0 <= y && x <= ScreenUtils.getScreenWidth() && y <= ScreenUtils.getScreenHeight()) {
             val gestureDescription = GestureDescription.Builder()
             val path = Path()
             path.moveTo(x, y)
             gestureDescription.addStroke(
                 GestureDescription.StrokeDescription(
-                    path, 0, ViewConfiguration.getTapTimeout().toLong()
+                    path, 0, duration
                 )
             )
             context.dispatchGesture(gestureDescription.build(), null, null)
@@ -156,8 +156,11 @@ val clickCenter: ActionFc = { context, node ->
             false
         }
     )
-
 }
+
+val clickCenter = getClickCenterAction("clickCenter", ViewConfiguration.getTapTimeout().toLong())
+
+val longClickCenter = getClickCenterAction("longClickCenter", (ViewConfiguration.getLongPressTimeout() * 1.1).toLong())
 
 val backFc: ActionFc = { context, _ ->
     ActionResult(
@@ -170,6 +173,7 @@ fun getActionFc(action: String?): ActionFc {
     return when (action) {
         "clickNode" -> clickNode
         "clickCenter" -> clickCenter
+        "longClickCenter" -> longClickCenter
         "back" -> backFc
         else -> click
     }


### PR DESCRIPTION
感谢 gkd，非常好用~

本 PR 扩展了 action，新增 long click。

long click 的场景需求：点击小红书的我不喜欢视频，来优化 App 推荐。

代码中 `ViewConfiguration.getLongPressTimeout() * 1.1` 的 `1.1` 是因为在原数值下会退化成单击。

结合以下规则使用（自测已通过）：

```
{
    "id": "com.xingin.xhs",
    "name": "小红书",
    "groups": [
        {
            "key": 1,
            "name": "首页-发现-不喜欢视频",
            "desc": "不喜欢视频，优化小红书推荐机制，只推图文",
            "rules": [
                {
                    "activityIds": "com.xingin.xhs.index.v2.IndexActivityV2",
                    "matches": "@FrameLayout > ImageView[id='com.xingin.xhs:id/dtr']",
                    "action": "longClickCenter",
                    "snapshotUrls": "https://i.gkd.li/import/13314707"
                },
                {
                    "activityIds": "com.xingin.xhs.index.v2.IndexActivityV2",
                    "matches": "[text='不喜欢该笔记']",
                    "action": "click",
                    "snapshotUrls": "https://i.gkd.li/import/13314995"
                }
            ]
        }
    ]
}
```

