### PR TITLE
perf: 优化 matchTime、matchDelay 计时逻辑

### DIFF
--- a/app/src/main/kotlin/li/songe/gkd/data/Rule.kt
+++ b/app/src/main/kotlin/li/songe/gkd/data/Rule.kt
@@ -93,8 +93,8 @@ data class Rule(
 
     var actionCount = Value(0)
 
-    var firstMatchTime = 0L
-    
+    var matchTimeStart = 0L
+
     var matchChangeTime = 0L
 
     val matchAllTime = (matchTime ?: 0) + (matchDelay ?: 0)

--- a/app/src/main/kotlin/li/songe/gkd/data/Rule.kt
+++ b/app/src/main/kotlin/li/songe/gkd/data/Rule.kt
@@ -93,6 +93,8 @@ data class Rule(
 
     var actionCount = Value(0)
 
+    var firstMatchTime = 0L
+    
     var matchChangeTime = 0L
 
     val matchAllTime = (matchTime ?: 0) + (matchDelay ?: 0)

--- a/app/src/main/kotlin/li/songe/gkd/service/AbState.kt
+++ b/app/src/main/kotlin/li/songe/gkd/service/AbState.kt
@@ -95,16 +95,18 @@ fun isAvailableRule(rule: Rule): Boolean {
     }
     if (rule.resetMatchTypeWhenActivity) {
         if (activityChangeTime != rule.matchChangeTime) {
-            // 当 界面 更新时, 重置操作延迟点, 重置点击次数
+            // 当 界面 更新时, 重置操作延迟点, 重置点击次数, 重置第一次匹配时间
             rule.actionDelayTriggerTime = 0
             rule.actionCount.value = 0
+            rule.firstMatchTime = t,
             rule.matchChangeTime = activityChangeTime
         }
     } else {
         if (appChangeTime != rule.matchChangeTime) {
-            // 当 切换APP 时, 重置点击次数
+            // 当 切换APP 时, 重置点击次数, 重置第一次匹配时间
             rule.actionDelayTriggerTime = 0
             rule.actionCount.value = 0
+            rule.firstMatchTime = t,
             rule.matchChangeTime = appChangeTime
         }
     }
@@ -115,26 +117,14 @@ fun isAvailableRule(rule: Rule): Boolean {
     }
     if (rule.matchDelay != null) {
         // 处于匹配延迟中
-        if (rule.resetMatchTypeWhenActivity) {
-            if (t - activityChangeTime < rule.matchDelay) {
-                return false
-            }
-        } else {
-            if (t - appChangeTime < rule.matchDelay) {
-                return false
-            }
+        if (t - firstMatchTime < rule.matchDelay) {
+            return false
         }
     }
     if (rule.matchTime != null) {
         // 超出了匹配时间
-        if (rule.resetMatchTypeWhenActivity) {
-            if (t - activityChangeTime > rule.matchAllTime) {
-                return false
-            }
-        } else {
-            if (t - appChangeTime > rule.matchAllTime) {
-                return false
-            }
+        if (t - firstMatchTime > rule.matchAllTime) {
+            return false
         }
     }
     if (rule.actionTriggerTime.value + rule.actionCd > t) return false // 处于冷却时间

--- a/app/src/main/kotlin/li/songe/gkd/service/AbState.kt
+++ b/app/src/main/kotlin/li/songe/gkd/service/AbState.kt
@@ -98,7 +98,7 @@ fun isAvailableRule(rule: Rule): Boolean {
             // 当 界面 更新时, 重置操作延迟点, 重置点击次数, 重置第一次匹配时间
             rule.actionDelayTriggerTime = 0
             rule.actionCount.value = 0
-            rule.firstMatchTime = t,
+            rule.matchTimeStart = t,
             rule.matchChangeTime = activityChangeTime
         }
     } else {
@@ -106,7 +106,7 @@ fun isAvailableRule(rule: Rule): Boolean {
             // 当 切换APP 时, 重置点击次数, 重置第一次匹配时间
             rule.actionDelayTriggerTime = 0
             rule.actionCount.value = 0
-            rule.firstMatchTime = t,
+            rule.matchTimeStart = t,
             rule.matchChangeTime = appChangeTime
         }
     }
@@ -117,13 +117,13 @@ fun isAvailableRule(rule: Rule): Boolean {
     }
     if (rule.matchDelay != null) {
         // 处于匹配延迟中
-        if (t - firstMatchTime < rule.matchDelay) {
+        if (t - matchTimeStart < rule.matchDelay) {
             return false
         }
     }
     if (rule.matchTime != null) {
         // 超出了匹配时间
-        if (t - firstMatchTime > rule.matchAllTime) {
+        if (t - matchTimeStart > rule.matchAllTime) {
             return false
         }
     }


### PR DESCRIPTION
- 优化为 从规则首次触发匹配时 开始计时。

原代码如下
https://github.com/gkd-kit/gkd/blob/5c430e0dbe5df2257c3bef5cbb3dd075083a3d5c/app/src/main/kotlin/li/songe/gkd/service/AbState.kt#L130-L138

例：
避免以下规则中，指定`resetMatch: 'app'`、`activityIds`时，`matchTime、matchDelay`错误以app切换时间计算，
实际应以进入`activityIds: ['com.unionpay.activity.UPActivityMain'],`的时间计算
```
{
  key: 9,
  name: '右侧悬浮广告',
  matchTime: 10000,
  actionMaximum: 1,
  resetMatch: 'app',
  quickFind: true,
  activityIds: ['com.unionpay.activity.UPActivityMain'],
  rules: [
    {
      matches:
        '[id="com.unionpay:id/frog_float"] >2 [id="com.unionpay:id/close_view"][visibleToUser=true]',
      snapshotUrls: 'https://i.gkd.li/import/12695699',
    },
  ],
},
```