### PR TITLE
fix: Pixel、Samsung 切换深色模式时系统状态栏图标与文字亮色、深色未切换

### DIFF
--- a/app/src/main/kotlin/li/songe/gkd/MainActivity.kt
+++ b/app/src/main/kotlin/li/songe/gkd/MainActivity.kt
@@ -17,6 +17,7 @@ import li.songe.gkd.composition.CompositionActivity
 import li.songe.gkd.composition.CompositionExt.useLifeCycleLog
 import li.songe.gkd.ui.NavGraphs
 import li.songe.gkd.ui.component.ConfirmDialog
+import li.songe.gkd.util.StatusBar
 import li.songe.gkd.ui.theme.AppTheme
 import li.songe.gkd.util.AuthDialog
 import li.songe.gkd.util.LocalLauncher
@@ -46,7 +47,7 @@ class MainActivity : CompositionActivity({
 
     setContent {
         val navController = rememberNavController()
-
+        StatusBar()
         AppTheme {
             ConfirmDialog()
             AuthDialog()

--- a/app/src/main/kotlin/li/songe/gkd/util/StatusBar.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/StatusBar.kt
@@ -1,0 +1,26 @@
+package li.songe.gkd.util
+
+import android.app.Activity
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.view.WindowInsetsControllerCompat
+
+@Composable
+fun StatusBar() {
+    val scope = rememberCoroutineScope()
+    val enableDarkTheme by storeFlow.map(scope) { s -> s.enableDarkTheme }.collectAsState()
+    val systemInDarkTheme = isSystemInDarkTheme()
+    val isDarkTheme = enableDarkTheme ?: systemInDarkTheme
+    val current = LocalContext.current
+    LaunchedEffect(isDarkTheme) {
+        (current as? Activity)?.window?.let { window ->
+            val controllerCompat = WindowInsetsControllerCompat(window, window.decorView)
+            controllerCompat.isAppearanceLightStatusBars = !isDarkTheme
+        }
+    }
+}


### PR DESCRIPTION
Pixel与Samsung设备在gkd的设置页面切换深色模式时，系统状态栏图标、文字颜色没有对应的深色与亮色变化。