### PR TITLE
fix:为DropDownMenu添加Offset Y偏移，使其显示在按钮的下面

### DIFF
--- a/app/src/main/kotlin/li/songe/gkd/ui/AppConfigPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/AppConfigPage.kt
@@ -43,8 +43,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewModelScope
@@ -80,6 +83,7 @@ import li.songe.gkd.util.throttle
 @Composable
 fun AppConfigPage(appId: String) {
     val navController = LocalNavController.current
+    val density = LocalDensity.current
     val vm = hiltViewModel<AppConfigVm>()
     val ruleSortType by vm.ruleSortTypeFlow.collectAsState()
     val appInfoCache by appInfoCacheFlow.collectAsState()
@@ -90,6 +94,9 @@ fun AppConfigPage(appId: String) {
     var expanded by remember { mutableStateOf(false) }
     val listState = rememberLazyListState()
     var isFirstVisit by remember { mutableStateOf(true) }
+    var actionButtonHeight by remember {
+        mutableStateOf(0.dp)
+    }
     LaunchedEffect(globalGroups.size, appGroups.size, ruleSortType.value) {
         if (isFirstVisit) {
             isFirstVisit = false
@@ -119,6 +126,8 @@ fun AppConfigPage(appId: String) {
             }, actions = {
                 IconButton(onClick = {
                     expanded = true
+                },modifier = Modifier.onGloballyPositioned {
+                    actionButtonHeight = with(density){ it.size.height.toDp()}
                 }) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.Sort,
@@ -131,7 +140,7 @@ fun AppConfigPage(appId: String) {
                 ) {
                     DropdownMenu(
                         expanded = expanded,
-                        onDismissRequest = { expanded = false }
+                        onDismissRequest = { expanded = false },offset = DpOffset(x = 0.dp, y = actionButtonHeight/2)
                     ) {
                         Text(
                             text = "排序",

--- a/app/src/main/kotlin/li/songe/gkd/ui/GlobalRuleExcludePage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/GlobalRuleExcludePage.kt
@@ -53,8 +53,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewModelScope
@@ -84,6 +87,7 @@ import li.songe.gkd.util.toast
 @Composable
 fun GlobalRuleExcludePage(subsItemId: Long, groupKey: Int) {
     val navController = LocalNavController.current
+    val density = LocalDensity.current
     val vm = hiltViewModel<GlobalRuleExcludeVm>()
     val rawSubs = vm.rawSubsFlow.collectAsState().value
     val group = vm.groupFlow.collectAsState().value
@@ -93,6 +97,7 @@ fun GlobalRuleExcludePage(subsItemId: Long, groupKey: Int) {
     val showSystemApp by vm.showSystemAppFlow.collectAsState()
     val showHiddenApp by vm.showHiddenAppFlow.collectAsState()
     val sortType by vm.sortTypeFlow.collectAsState()
+
 
     var showEditDlg by remember {
         mutableStateOf(false)
@@ -112,6 +117,9 @@ fun GlobalRuleExcludePage(subsItemId: Long, groupKey: Int) {
         listState.animateScrollToItem(0)
     })
     var expanded by remember { mutableStateOf(false) }
+    var actionButtonHeight by remember {
+        mutableStateOf(0.dp)
+    }
     Scaffold(modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection), topBar = {
         TopAppBar(scrollBehavior = scrollBehavior, navigationIcon = {
             IconButton(onClick = {
@@ -161,6 +169,8 @@ fun GlobalRuleExcludePage(subsItemId: Long, groupKey: Int) {
 
                 IconButton(onClick = {
                     expanded = true
+                },modifier = Modifier.onGloballyPositioned {
+                    actionButtonHeight = with(density){ it.size.height.toDp()}
                 }) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.Sort,
@@ -173,7 +183,7 @@ fun GlobalRuleExcludePage(subsItemId: Long, groupKey: Int) {
                 ) {
                     DropdownMenu(
                         expanded = expanded,
-                        onDismissRequest = { expanded = false }
+                        onDismissRequest = { expanded = false },offset = DpOffset(x = 0.dp, y = actionButtonHeight/2)
                     ) {
                         Text(
                             text = "排序",

--- a/app/src/main/kotlin/li/songe/gkd/ui/SubsPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/SubsPage.kt
@@ -43,7 +43,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewModelScope
 import com.blankj.utilcode.util.LogUtils
@@ -82,6 +86,7 @@ fun SubsPage(
 ) {
     val navController = LocalNavController.current
     val mainVm = LocalMainViewModel.current
+    val density = LocalDensity.current
 
     val vm = hiltViewModel<SubsVm>()
     val subsItem = vm.subsItemFlow.collectAsState().value
@@ -117,6 +122,9 @@ fun SubsPage(
     val sortType by vm.sortTypeFlow.collectAsState()
     val listState = rememberLazyListState()
     var isFirstVisit by remember { mutableStateOf(false) }
+    var actionButtonHeight by remember {
+        mutableStateOf(0.dp)
+    }
     LaunchedEffect(
         appAndConfigs.size,
         sortType.value,
@@ -172,7 +180,9 @@ fun SubsPage(
                     }) {
                         Icon(Icons.Outlined.Search, contentDescription = null)
                     }
-                    IconButton(onClick = { expanded = true }) {
+                    IconButton(onClick = { expanded = true },modifier = Modifier.onGloballyPositioned {
+                        actionButtonHeight = with(density){ it.size.height.toDp()}
+                    }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.Sort, contentDescription = null
                         )
@@ -180,7 +190,7 @@ fun SubsPage(
                     Box(
                         modifier = Modifier.wrapContentSize(Alignment.TopStart)
                     ) {
-                        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false },offset = DpOffset(x = 0.dp, y = actionButtonHeight/2)) {
                             Text(
                                 text = "排序",
                                 modifier = Modifier.menuPadding(),

--- a/app/src/main/kotlin/li/songe/gkd/ui/home/AppListPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/home/AppListPage.kt
@@ -52,11 +52,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewModelScope
@@ -90,6 +93,7 @@ fun useAppListPage(): ScaffoldExt {
     val navController = LocalNavController.current
     val context = LocalContext.current as MainActivity
     val softwareKeyboardController = LocalSoftwareKeyboardController.current
+    val density = LocalDensity.current
 
     val vm = hiltViewModel<HomeVm>()
     val showSystemApp by vm.showSystemAppFlow.collectAsState()
@@ -119,6 +123,9 @@ fun useAppListPage(): ScaffoldExt {
         }
     })
     val listState = rememberLazyListState()
+    var actionButtonHeight by remember {
+        mutableStateOf(0.dp)
+    }
 
     var isFirstVisit by remember { mutableStateOf(false) }
     LaunchedEffect(key1 = orderedAppInfos, block = {
@@ -201,6 +208,8 @@ fun useAppListPage(): ScaffoldExt {
                     }
                     IconButton(onClick = {
                         expanded = true
+                    },modifier = Modifier.onGloballyPositioned {
+                        actionButtonHeight = with(density){ it.size.height.toDp()}
                     }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.Sort,
@@ -213,7 +222,7 @@ fun useAppListPage(): ScaffoldExt {
                     ) {
                         DropdownMenu(
                             expanded = expanded,
-                            onDismissRequest = { expanded = false }
+                            onDismissRequest = { expanded = false },offset = DpOffset(x = 0.dp, y = actionButtonHeight/2)
                         ) {
                             Text(
                                 text = "排序",

--- a/app/src/main/kotlin/li/songe/gkd/ui/home/SubsManagePage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/home/SubsManagePage.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -44,14 +45,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewModelScope
@@ -92,6 +99,7 @@ val subsNav = BottomNavItem(
 fun useSubsManagePage(): ScaffoldExt {
     val launcher = LocalLauncher.current
     val mainVm = LocalMainViewModel.current
+    val density = LocalDensity.current
 
     val vm = hiltViewModel<HomeVm>()
     val subItems by subsItemsFlow.collectAsState()
@@ -112,6 +120,10 @@ fun useSubsManagePage(): ScaffoldExt {
     var isSelectedMode by remember { mutableStateOf(false) }
     var selectedIds by remember { mutableStateOf(emptySet<Long>()) }
     val draggedFlag = remember { Value(false) }
+    var actionButtonHeight by remember {
+        mutableStateOf(0.dp)
+    }
+
     LaunchedEffect(key1 = isSelectedMode) {
         if (!isSelectedMode && selectedIds.isNotEmpty()) {
             selectedIds = emptySet()
@@ -246,6 +258,8 @@ fun useSubsManagePage(): ScaffoldExt {
                         } else {
                             expanded = true
                         }
+                    }, modifier = Modifier.onGloballyPositioned {
+                        actionButtonHeight = with(density){ it.size.height.toDp()}
                     }) {
                         Icon(
                             imageVector = Icons.Default.MoreVert,
@@ -256,7 +270,7 @@ fun useSubsManagePage(): ScaffoldExt {
                 Box(
                     modifier = Modifier.wrapContentSize(Alignment.TopStart)
                 ) {
-                    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }, offset = DpOffset(x = 0.dp, y = actionButtonHeight/2)) {
                         if (isSelectedMode) {
                             DropdownMenuItem(
                                 text = {


### PR DESCRIPTION
有几处点击actionBar里按钮打开的popup菜单其顶部位置在按钮的中间，添加了按钮高度的一半作为offset y，使其在按钮的下方，看起来更美观
-------------------------------

before:
![微信图片_20240805123020](https://github.com/user-attachments/assets/fa0cc500-2f6b-4e9f-aa81-301039330237)
![微信图片_20240805123023](https://github.com/user-attachments/assets/bbd67cdf-47a8-4fc1-b3ff-00dd660a9bda)
-------------------------------

after:
![微信截图_20240805115938](https://github.com/user-attachments/assets/93071d21-35a6-4535-ad86-6853fc94a03f)
![微信截图_20240805115952](https://github.com/user-attachments/assets/a32786f7-d61f-4a58-8e88-ac25be976f00)
![微信截图_20240805120008](https://github.com/user-attachments/assets/2f4ef920-1bee-41c8-83f6-d4d7a33b28d6)
