### PR TITLE
perf: non zipped artifacts for apks

### DIFF
--- a/.github/workflows/Build-Apk.yml
+++ b/.github/workflows/Build-Apk.yml
@@ -38,12 +38,13 @@ jobs:
       - run: chmod 777 ./gradlew
       - run: ./gradlew app:assembleGkdRelease
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release
           path: app/build/outputs/apk/gkd/release
+          archive: false
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: outputs
           path: app/build/outputs


### PR DESCRIPTION
优化 Build-Apk，直接上传未经压缩的apk文件，方便用户下载安装

相关说明：https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/