### PR TITLE
refactor: img view UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -283,6 +283,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.coil.network)
     implementation(libs.coil.gif)
+    implementation(libs.telephoto.zoomable)
 
     implementation(libs.exp4j)
 

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
@@ -34,6 +36,7 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -193,7 +196,8 @@ private fun UriImage(uri: String) {
     }
     val painter = rememberAsyncImagePainter(model)
     val state by painter.state.collectAsState()
-    when (state) {
+    val stateVal = state
+    when (stateVal) {
         AsyncImagePainter.State.Empty -> {}
         is AsyncImagePainter.State.Loading -> {
             Column(
@@ -234,6 +238,16 @@ private fun UriImage(uri: String) {
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodyMedium
                 )
+                stateVal.result.throwable.message?.let { msg ->
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = msg,
+                        color = MaterialTheme.colorScheme.outline,
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        textAlign = TextAlign.Center
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -89,10 +89,17 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 @Serializable
+data class ImagePreviewItem(
+    val uri: String,
+    val title: String? = null,
+)
+
+@Serializable
 data class ImagePreviewRoute(
     val title: String? = null,
     val uri: String? = null,
     val uris: List<String> = emptyList(),
+    val items: List<ImagePreviewItem> = emptyList(),
 ) : NavKey
 
 @Composable
@@ -101,14 +108,21 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
     val context = LocalActivity.current as MainActivity
     var showBars by remember { mutableStateOf(true) }
 
-    // 路由同时支持单图和多图，这里先统一成一个列表，后续 pager / 单图逻辑都共用它。
-    val previewUris = remember(route.uri, route.uris) {
-        route.uris.ifEmpty {
-            route.uri?.let(::listOf) ?: emptyList()
+    // 路由同时兼容旧的 uri/uris 和新的 items，预览页内部统一按图片项处理。
+    val previewItems = remember(route.uri, route.uris, route.items) {
+        when {
+            route.items.isNotEmpty() -> route.items
+            route.uris.isNotEmpty() -> route.uris.map { uri ->
+                ImagePreviewItem(uri = uri)
+            }
+
+            route.uri != null -> listOf(ImagePreviewItem(uri = route.uri))
+            else -> emptyList()
         }
     }
-    val singleUri = previewUris.singleOrNull()
-    val pagerState = rememberPagerState(pageCount = { previewUris.size.coerceAtLeast(1) })
+    val previewUris = remember(previewItems) { previewItems.map { it.uri } }
+    val singleItem = previewItems.singleOrNull()
+    val pagerState = rememberPagerState(pageCount = { previewItems.size.coerceAtLeast(1) })
 
     // 这个页面需要接近相册页的沉浸式效果，因此进入时隐藏状态栏，离开时恢复原设置。
     DisposableEffect(Unit) {
@@ -145,20 +159,20 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
             .fillMaxSize()
     ) {
         when {
-            singleUri != null -> {
+            singleItem != null -> {
                 UriImage(
-                    uri = singleUri,
+                    uri = singleItem.uri,
                     onToggleBars = { showBars = !showBars },
                 )
             }
 
-            previewUris.isNotEmpty() -> {
+            previewItems.isNotEmpty() -> {
                 HorizontalPager(
                     modifier = Modifier.fillMaxSize(),
                     state = pagerState,
                     pageContent = { index ->
                         UriImage(
-                            uri = previewUris[index],
+                            uri = previewItems[index].uri,
                             onToggleBars = { showBars = !showBars },
                         )
                     }
@@ -175,7 +189,8 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                 .fillMaxWidth()
         ) {
             Column {
-                val currentUri = singleUri ?: previewUris.getOrNull(pagerState.currentPage)
+                val currentPreviewItem = singleItem ?: previewItems.getOrNull(pagerState.currentPage)
+                val currentUri = currentPreviewItem?.uri
                 PerfTopAppBar(
                     modifier = Modifier.background(Color.Black.copy(alpha = 0.5f)),
                     navigationIcon = {
@@ -186,17 +201,60 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                         )
                     },
                     title = {
-                        route.title?.let { title ->
-                            Text(
-                                text = title,
-                                maxLines = 1,
-                                softWrap = false,
-                                overflow = TextOverflow.MiddleEllipsis,
-                                style = MaterialTheme.typography.titleLarge.copy(
-                                    color = Color.White,
-                                    fontWeight = FontWeight.Medium
+                        val baseTitle = route.title?.takeIf { it.isNotBlank() }
+                        val itemTitle = currentPreviewItem?.title
+                            ?.takeIf { it.isNotBlank() && it != baseTitle }
+                        when {
+                            baseTitle != null && itemTitle != null -> {
+                                Column {
+                                    Text(
+                                        text = baseTitle,
+                                        maxLines = 1,
+                                        softWrap = false,
+                                        overflow = TextOverflow.MiddleEllipsis,
+                                        style = MaterialTheme.typography.titleLarge.copy(
+                                            color = Color.White,
+                                            fontWeight = FontWeight.Medium
+                                        )
+                                    )
+                                    Text(
+                                        text = itemTitle,
+                                        maxLines = 1,
+                                        softWrap = false,
+                                        overflow = TextOverflow.MiddleEllipsis,
+                                        style = MaterialTheme.typography.titleSmall.copy(
+                                            color = Color.White.copy(alpha = 0.8f),
+                                            fontWeight = FontWeight.Normal
+                                        )
+                                    )
+                                }
+                            }
+
+                            baseTitle != null -> {
+                                Text(
+                                    text = baseTitle,
+                                    maxLines = 1,
+                                    softWrap = false,
+                                    overflow = TextOverflow.MiddleEllipsis,
+                                    style = MaterialTheme.typography.titleLarge.copy(
+                                        color = Color.White,
+                                        fontWeight = FontWeight.Medium
+                                    )
                                 )
-                            )
+                            }
+
+                            itemTitle != null -> {
+                                Text(
+                                    text = itemTitle,
+                                    maxLines = 1,
+                                    softWrap = false,
+                                    overflow = TextOverflow.MiddleEllipsis,
+                                    style = MaterialTheme.typography.titleLarge.copy(
+                                        color = Color.White,
+                                        fontWeight = FontWeight.Medium
+                                    )
+                                )
+                            }
                         }
                     },
                     actions = {
@@ -216,7 +274,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                     )
                 )
 
-                if (previewUris.size > 1) {
+                if (previewItems.size > 1) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -224,7 +282,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = "${pagerState.currentPage + 1} / ${previewUris.size}",
+                            text = "${pagerState.currentPage + 1} / ${previewItems.size}",
                             modifier = Modifier
                                 .background(Color.Black.copy(alpha = 0.5f), CircleShape)
                                 .padding(horizontal = 12.dp, vertical = 4.dp),

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -2,17 +2,25 @@ package li.songe.gkd.ui
 
 import android.webkit.URLUtil
 import androidx.activity.compose.LocalActivity
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.AnimationConstants.DefaultDurationMillis
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
@@ -27,12 +35,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -83,6 +94,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
     val uris = route.uris
     val mainVm = LocalMainViewModel.current
     val context = LocalActivity.current as MainActivity
+    var showBars by remember { mutableStateOf(true) }
     DisposableEffect(null) {
         val controller = WindowCompat.getInsetsController(context.window, context.window.decorView)
         val oldBehavior = controller.systemBarsBehavior
@@ -98,50 +110,61 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
         modifier = Modifier
             .background(MaterialTheme.colorScheme.background)
             .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    showBars = !showBars
+                })
+            }
     ) {
         val showUri = uri ?: if (uris.size == 1) uris.first() else null
         val state = rememberPagerState { uris.size }
-        PerfTopAppBar(
+        AnimatedVisibility(
+            visible = showBars,
+            enter = fadeIn() + slideInVertically(initialOffsetY = { -it }),
+            exit = fadeOut() + slideOutVertically(targetOffsetY = { -it }),
             modifier = Modifier
                 .zIndex(1f)
-                .fillMaxWidth(),
-            navigationIcon = {
-                PerfIconButton(imageVector = PerfIcon.ArrowBack, onClick = {
-                    mainVm.popPage()
-                })
-            },
-            title = {
-                if (title != null) {
-                    Text(
-                        text = title,
-                        maxLines = 1,
-                        softWrap = false,
-                        overflow = TextOverflow.MiddleEllipsis,
-                        style = MaterialTheme.typography.titleLarge.copy(
-                            color = MaterialTheme.colorScheme.onBackground,
-                            shadow = Shadow(
-                                color = Color.Black.copy(alpha = 0.7f),
-                                blurRadius = with(LocalDensity.current) { 2.dp.toPx() },
-                                offset = with(LocalDensity.current) {
-                                    Offset(1.dp.toPx(), 1.dp.toPx())
-                                }
+                .fillMaxWidth()
+        ) {
+            PerfTopAppBar(
+                navigationIcon = {
+                    PerfIconButton(imageVector = PerfIcon.ArrowBack, onClick = {
+                        mainVm.popPage()
+                    })
+                },
+                title = {
+                    if (title != null) {
+                        Text(
+                            text = title,
+                            maxLines = 1,
+                            softWrap = false,
+                            overflow = TextOverflow.MiddleEllipsis,
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                color = MaterialTheme.colorScheme.onBackground,
+                                shadow = Shadow(
+                                    color = Color.Black.copy(alpha = 0.7f),
+                                    blurRadius = with(LocalDensity.current) { 2.dp.toPx() },
+                                    offset = with(LocalDensity.current) {
+                                        Offset(1.dp.toPx(), 1.dp.toPx())
+                                    }
+                                )
                             )
                         )
-                    )
-                }
-            },
-            actions = {
-                val currentUri = showUri ?: uris.getOrNull(state.currentPage)
-                if (currentUri != null && URLUtil.isNetworkUrl(currentUri)) {
-                    PerfIconButton(imageVector = PerfIcon.OpenInNew, onClick = throttle(fn = {
-                        mainVm.openUrl(currentUri)
-                    }))
-                }
-            },
-            colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = MaterialTheme.colorScheme.background.copy(alpha = 0.1f)
+                    }
+                },
+                actions = {
+                    val currentUri = showUri ?: uris.getOrNull(state.currentPage)
+                    if (currentUri != null && URLUtil.isNetworkUrl(currentUri)) {
+                        PerfIconButton(imageVector = PerfIcon.OpenInNew, onClick = throttle(fn = {
+                            mainVm.openUrl(currentUri)
+                        }))
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background.copy(alpha = 0.1f)
+                )
             )
-        )
+        }
         if (showUri != null) {
             UriImage(showUri)
         } else if (uris.isNotEmpty()) {
@@ -155,23 +178,30 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                         UriImage(uris[it])
                     }
                 )
-                Box(
-                    Modifier
-                        .align(Alignment.BottomCenter)
-                        .fillMaxWidth()
-                        .padding(bottom = 150.dp),
-                    contentAlignment = Alignment.BottomCenter
+                AnimatedVisibility(
+                    visible = showBars,
+                    enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
+                    exit = fadeOut() + slideOutVertically(targetOffsetY = { it }),
+                    modifier = Modifier.align(Alignment.BottomCenter)
                 ) {
-                    Text(
-                        text = "${state.currentPage + 1}/${uris.size}",
-                        style = MaterialTheme.typography.titleLarge.copy(
-                            color = MaterialTheme.colorScheme.onPrimary,
-                            shadow = Shadow(
-                                color = Color.Black.copy(alpha = 0.8f),
-                                blurRadius = with(LocalDensity.current) { 3.dp.toPx() }
+                    val navBarsPadding = WindowInsets.navigationBars.asPaddingValues()
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 64.dp + navBarsPadding.calculateBottomPadding()),
+                        contentAlignment = Alignment.BottomCenter
+                    ) {
+                        Text(
+                            text = "${state.currentPage + 1}/${uris.size}",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                shadow = Shadow(
+                                    color = Color.Black.copy(alpha = 0.8f),
+                                    blurRadius = with(LocalDensity.current) { 3.dp.toPx() }
+                                )
                             )
                         )
-                    )
+                    }
                 }
             }
         }
@@ -227,13 +257,16 @@ private fun UriImage(uri: String) {
         }
 
         is AsyncImagePainter.State.Error -> {
+            val reload = throttle { painter.restart() }
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
                 Text(
-                    modifier = Modifier.clickable(onClick = throttle { painter.restart() }),
+                    modifier = Modifier.pointerInput(Unit) {
+                        detectTapGestures(onTap = { reload() })
+                    },
                     text = "加载失败, 点击重试",
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodyMedium

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -3,7 +3,6 @@ package li.songe.gkd.ui
 import android.webkit.URLUtil
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationConstants.DefaultDurationMillis
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -11,14 +10,9 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.calculatePan
-import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -41,14 +35,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -71,7 +63,6 @@ import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import li.songe.gkd.MainActivity
 import li.songe.gkd.app
@@ -82,10 +73,11 @@ import li.songe.gkd.ui.share.LocalMainViewModel
 import li.songe.gkd.util.AndroidTarget
 import li.songe.gkd.util.coilCacheDir
 import li.songe.gkd.util.throttle
+import me.saket.telephoto.zoomable.ZoomableContentLocation
+import me.saket.telephoto.zoomable.rememberZoomableState
+import me.saket.telephoto.zoomable.zoomable
 import okhttp3.OkHttpClient
 import okio.Path.Companion.toOkioPath
-import kotlin.math.abs
-import kotlin.math.max
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -98,15 +90,21 @@ data class ImagePreviewRoute(
 
 @Composable
 fun ImagePreviewPage(route: ImagePreviewRoute) {
-    val title = route.title
-    val uri = route.uri
-    val uris = route.uris
     val mainVm = LocalMainViewModel.current
     val context = LocalActivity.current as MainActivity
     var showBars by remember { mutableStateOf(true) }
-    var userScrollEnabled by remember { mutableStateOf(true) }
 
-    DisposableEffect(null) {
+    // 路由同时支持单图和多图，这里先统一成一个列表，后续 pager / 单图逻辑都共用它。
+    val previewUris = remember(route.uri, route.uris) {
+        route.uris.ifEmpty {
+            route.uri?.let(::listOf) ?: emptyList()
+        }
+    }
+    val singleUri = previewUris.singleOrNull()
+    val pagerState = rememberPagerState(pageCount = { previewUris.size.coerceAtLeast(1) })
+
+    // 这个页面需要接近相册页的沉浸式效果，因此进入时隐藏状态栏，离开时恢复原设置。
+    DisposableEffect(Unit) {
         val controller = WindowCompat.getInsetsController(context.window, context.window.decorView)
         val oldBehavior = controller.systemBarsBehavior
         controller.systemBarsBehavior =
@@ -117,41 +115,32 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
             controller.show(WindowInsetsCompat.Type.statusBars())
         }
     }
+
     Box(
         modifier = Modifier
             .background(Color.Black)
             .fillMaxSize()
     ) {
-        val showUri = uri ?: if (uris.size == 1) uris.first() else null
-        val state = rememberPagerState { uris.size }
+        when {
+            singleUri != null -> {
+                UriImage(
+                    uri = singleUri,
+                    onToggleBars = { showBars = !showBars },
+                )
+            }
 
-        LaunchedEffect(state.currentPage) {
-            userScrollEnabled = true
-        }
-
-        if (showUri != null) {
-            UriImage(
-                uri = showUri,
-                onToggleBars = { showBars = !showBars },
-                onScaleChange = { userScrollEnabled = it <= 1f }
-            )
-        } else if (uris.isNotEmpty()) {
-            HorizontalPager(
-                modifier = Modifier.fillMaxSize(),
-                state = state,
-                userScrollEnabled = userScrollEnabled,
-                pageContent = { index ->
-                    UriImage(
-                        uri = uris[index],
-                        onToggleBars = { showBars = !showBars },
-                        onScaleChange = { scale ->
-                            if (index == state.currentPage) {
-                                userScrollEnabled = scale <= 1f
-                            }
-                        }
-                    )
-                }
-            )
+            previewUris.isNotEmpty() -> {
+                HorizontalPager(
+                    modifier = Modifier.fillMaxSize(),
+                    state = pagerState,
+                    pageContent = { index ->
+                        UriImage(
+                            uri = previewUris[index],
+                            onToggleBars = { showBars = !showBars },
+                        )
+                    }
+                )
+            }
         }
 
         AnimatedVisibility(
@@ -163,6 +152,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                 .fillMaxWidth()
         ) {
             Column {
+                val currentUri = singleUri ?: previewUris.getOrNull(pagerState.currentPage)
                 PerfTopAppBar(
                     modifier = Modifier.background(Color.Black.copy(alpha = 0.5f)),
                     navigationIcon = {
@@ -173,7 +163,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                         )
                     },
                     title = {
-                        if (title != null) {
+                        route.title?.let { title ->
                             Text(
                                 text = title,
                                 maxLines = 1,
@@ -187,7 +177,6 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                         }
                     },
                     actions = {
-                        val currentUri = showUri ?: uris.getOrNull(state.currentPage)
                         if (currentUri != null && URLUtil.isNetworkUrl(currentUri)) {
                             PerfIconButton(
                                 imageVector = PerfIcon.OpenInNew,
@@ -204,7 +193,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                     )
                 )
 
-                if (uris.size > 1) {
+                if (previewUris.size > 1) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -212,7 +201,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = "${state.currentPage + 1} / ${uris.size}",
+                            text = "${pagerState.currentPage + 1} / ${previewUris.size}",
                             modifier = Modifier
                                 .background(Color.Black.copy(alpha = 0.5f), CircleShape)
                                 .padding(horizontal = 12.dp, vertical = 4.dp),
@@ -228,24 +217,27 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
     }
 }
 
-// 图片预览一些功能demo
 @Composable
 private fun UriImage(
     uri: String,
     onToggleBars: () -> Unit = {},
-    onScaleChange: (Float) -> Unit = {}
 ) {
     val context = LocalContext.current
+    // 手势层切至Telephoto,loading,error还是使用AsyncImagePainter.State统一驱动
     val model = remember(uri) {
-        ImageRequest.Builder(context).data(uri)
-            .crossfade(DefaultDurationMillis).run {
+        ImageRequest.Builder(context)
+            .data(uri)
+            .crossfade(DefaultDurationMillis)
+            .run {
                 if (URLUtil.isNetworkUrl(uri)) {
                     this
                 } else {
-                    diskCachePolicy(CachePolicy.DISABLED).memoryCachePolicy(CachePolicy.DISABLED)
+                    diskCachePolicy(CachePolicy.DISABLED)
+                        .memoryCachePolicy(CachePolicy.DISABLED)
                 }
             }
-            .build().apply {
+            .build()
+            .apply {
                 imageLoader.enqueue(this)
             }
     }
@@ -257,12 +249,15 @@ private fun UriImage(
         contentAlignment = Alignment.Center
     ) {
         when (val stateVal = state) {
-            AsyncImagePainter.State.Empty -> {}
+            AsyncImagePainter.State.Empty -> Unit
+
             is AsyncImagePainter.State.Loading -> {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .pointerInput(uri) { detectTapGestures(onTap = { onToggleBars() }) },
+                        .pointerInput(uri) {
+                            detectTapGestures(onTap = { onToggleBars() })
+                        },
                     contentAlignment = Alignment.Center
                 ) {
                     CircularProgressIndicator(modifier = Modifier.size(40.dp))
@@ -270,120 +265,11 @@ private fun UriImage(
             }
 
             is AsyncImagePainter.State.Success -> {
-                val scope = rememberCoroutineScope()
-                val scale = remember(uri) { Animatable(1f) }
-                val offsetX = remember(uri) { Animatable(0f) }
-                val offsetY = remember(uri) { Animatable(0f) }
-
-                BoxWithConstraints(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    val containerWidth = constraints.maxWidth.toFloat()
-                    val containerHeight = constraints.maxHeight.toFloat()
-
-                    val intrinsicSize = painter.intrinsicSize
-                    val imageHeight = remember(intrinsicSize, containerWidth) {
-                        if (intrinsicSize != Size.Unspecified && intrinsicSize.width > 0) {
-                            containerWidth * (intrinsicSize.height / intrinsicSize.width)
-                        } else {
-                            containerHeight
-                        }
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .pointerInput(uri) {
-                                detectTapGestures(
-                                    onTap = { onToggleBars() },
-                                    onDoubleTap = { tapOffset ->
-                                        scope.launch {
-                                            // 双指缩放控制
-                                            if (scale.value > 1f) {
-                                                launch { scale.animateTo(1f) }
-                                                launch { offsetX.animateTo(0f) }
-                                                launch { offsetY.animateTo(0f) }
-                                                onScaleChange(1f)
-                                            } else {
-                                                // 双指缩放以两个手指开合你看到的上下手指中心点为中心的偏移量缩放控制计算，防止在中间缩放图片
-                                                val targetScale = 3f
-                                                val center = Offset(containerWidth / 2, containerHeight / 2)
-                                                var targetOffsetX = (center.x - tapOffset.x) * (targetScale - 1)
-                                                var targetOffsetY = (center.y - tapOffset.y) * (targetScale - 1)
-
-                                                val maxOffsetX = max(0f, (containerWidth * targetScale - containerWidth) / 2f)
-                                                val maxOffsetY = max(0f, (imageHeight * targetScale - containerHeight) / 2f)
-                                                targetOffsetX = targetOffsetX.coerceIn(-maxOffsetX, maxOffsetX)
-                                                targetOffsetY = targetOffsetY.coerceIn(-maxOffsetY, maxOffsetY)
-
-                                                launch { scale.animateTo(targetScale) }
-                                                launch { offsetX.animateTo(targetOffsetX) }
-                                                launch { offsetY.animateTo(targetOffsetY) }
-                                                onScaleChange(targetScale)
-                                            }
-                                        }
-                                    }
-                                )
-                            }
-                            .pointerInput(uri, containerWidth, containerHeight, imageHeight) {
-                                awaitEachGesture {
-                                    awaitFirstDown(requireUnconsumed = false)
-                                    do {
-                                        val event = awaitPointerEvent()
-                                        val zoomChange = event.calculateZoom()
-                                        val panChange = event.calculatePan()
-
-                                        if (zoomChange != 1f) {
-                                            val targetScale = (scale.value * zoomChange).coerceIn(1f, 5f)
-                                            scope.launch {
-                                                scale.snapTo(targetScale)
-                                            }
-                                            onScaleChange(targetScale)
-                                            event.changes.forEach { it.consume() }
-                                        // 处理平移手势拖动
-                                        } else if (scale.value > 1f) {
-                                            val currentScale = scale.value
-                                            val maxOffsetX = max(0f, (containerWidth * currentScale - containerWidth) / 2f)
-                                            val maxOffsetY = max(0f, (imageHeight * currentScale - containerHeight) / 2f)
-
-                                            val atLeftEdge = offsetX.value >= maxOffsetX
-                                            val atRightEdge = offsetX.value <= -maxOffsetX
-
-                                            val isHorizontalPan = abs(panChange.x) > abs(panChange.y)
-                                            val isScrollingOut = (panChange.x > 0 && atLeftEdge) || (panChange.x < 0 && atRightEdge)
-
-                                            if (isHorizontalPan && isScrollingOut) {
-                                                // 让 HorizontalPager 处理
-                                            } else {
-                                                scope.launch {
-                                                    offsetX.snapTo((offsetX.value + panChange.x).coerceIn(-maxOffsetX, maxOffsetX))
-                                                    offsetY.snapTo((offsetY.value + panChange.y).coerceIn(-maxOffsetY, maxOffsetY))
-                                                }
-                                                event.changes.forEach { it.consume() }
-                                            }
-                                        }
-                                    } while (event.changes.any { it.pressed })
-                                }
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        // 渲染图片
-                        Image(
-                            painter = painter,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .graphicsLayer(
-                                    scaleX = scale.value,
-                                    scaleY = scale.value,
-                                    translationX = offsetX.value,
-                                    translationY = offsetY.value
-                                )
-                                .fillMaxWidth(),
-                            contentScale = ContentScale.FillWidth
-                        )
-                    }
-                }
+                ZoomableImageContent(
+                    uri = uri,
+                    painter = painter,
+                    onToggleBars = onToggleBars,
+                )
             }
 
             is AsyncImagePainter.State.Error -> {
@@ -391,7 +277,9 @@ private fun UriImage(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .pointerInput(uri) { detectTapGestures(onTap = { onToggleBars() }) },
+                        .pointerInput(uri) {
+                            detectTapGestures(onTap = { onToggleBars() })
+                        },
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center,
                 ) {
@@ -419,6 +307,40 @@ private fun UriImage(
     }
 }
 
+@Composable
+private fun ZoomableImageContent(
+    uri: String,
+    painter: Painter,
+    onToggleBars: () -> Unit,
+) {
+    // 每个 pager page 都独立持有一个 ZoomableState，避免翻页后复用缩放位置。
+    val zoomableState = rememberZoomableState()
+    val intrinsicSize = painter.intrinsicSize
+
+    // Image() 的绘制区域和实际图片内容边界并不总是完全一致。
+    // 把内容位置告诉 Telephoto 后，边缘检测和与 pager 的手势协同会更稳定。
+    LaunchedEffect(uri, intrinsicSize) {
+        if (intrinsicSize != Size.Unspecified && intrinsicSize.width > 0f && intrinsicSize.height > 0f) {
+            zoomableState.setContentLocation(
+                ZoomableContentLocation.scaledInsideAndCenterAligned(intrinsicSize)
+            )
+        }
+    }
+
+    Image(
+        painter = painter,
+        contentDescription = null,
+        modifier = Modifier
+            .fillMaxSize()
+            .zoomable(
+                state = zoomableState,
+                onClick = { onToggleBars() },
+            ),
+        contentScale = ContentScale.Fit,
+        alignment = Alignment.Center,
+    )
+}
+
 private val imageLoader by lazy {
     ImageLoader.Builder(app)
         .diskCache {
@@ -442,7 +364,8 @@ private val imageLoader by lazy {
                             .writeTimeout(30.seconds.toJavaDuration())
                             .build()
                     }
-                ))
+                )
+            )
         }
         .build()
 }

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -123,6 +123,22 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
         }
     }
 
+    // 规则组示例图通常会连续查看，因此进入预览后直接预加载组内所有图片
+    LaunchedEffect(previewUris) {
+        if (previewUris.size <= 1) return@LaunchedEffect
+        previewUris
+            .drop(1)
+            .filter(URLUtil::isNetworkUrl)
+            .forEach { preloadUri ->
+                imageLoader.enqueue(
+                    buildPreviewImageRequest(
+                        context = context,
+                        uri = preloadUri,
+                    )
+                )
+            }
+    }
+
     Box(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.background)
@@ -277,18 +293,10 @@ private fun UriImage(
 
     // 手势层切至 Telephoto，loading / error 还是使用 AsyncImagePainter.State 统一驱动。
     val model = remember(uri) {
-        ImageRequest.Builder(context)
-            .data(uri)
-            .crossfade(DefaultDurationMillis)
-            .run {
-                if (isNetworkImage) {
-                    this
-                } else {
-                    diskCachePolicy(CachePolicy.DISABLED)
-                        .memoryCachePolicy(CachePolicy.DISABLED)
-                }
-            }
-            .build()
+        buildPreviewImageRequest(
+            context = context,
+            uri = uri,
+        )
     }
     val painter = rememberAsyncImagePainter(
         model = model,
@@ -408,6 +416,24 @@ private fun ZoomableImageContent(
             alignment = Alignment.Center,
         )
     }
+}
+
+private fun buildPreviewImageRequest(
+    context: android.content.Context,
+    uri: String,
+): ImageRequest {
+    return ImageRequest.Builder(context)
+        .data(uri)
+        .crossfade(DefaultDurationMillis)
+        .run {
+            if (URLUtil.isNetworkUrl(uri)) {
+                this
+            } else {
+                diskCachePolicy(CachePolicy.DISABLED)
+                    .memoryCachePolicy(CachePolicy.DISABLED)
+            }
+        }
+        .build()
 }
 
 private val imageLoader by lazy {

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -3,6 +3,7 @@ package li.songe.gkd.ui
 import android.webkit.URLUtil
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationConstants.DefaultDurationMillis
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -10,24 +11,24 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -35,14 +36,19 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -65,6 +71,7 @@ import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import li.songe.gkd.MainActivity
 import li.songe.gkd.app
@@ -77,6 +84,8 @@ import li.songe.gkd.util.coilCacheDir
 import li.songe.gkd.util.throttle
 import okhttp3.OkHttpClient
 import okio.Path.Companion.toOkioPath
+import kotlin.math.abs
+import kotlin.math.max
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -95,6 +104,8 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
     val mainVm = LocalMainViewModel.current
     val context = LocalActivity.current as MainActivity
     var showBars by remember { mutableStateOf(true) }
+    var userScrollEnabled by remember { mutableStateOf(true) }
+
     DisposableEffect(null) {
         val controller = WindowCompat.getInsetsController(context.window, context.window.decorView)
         val oldBehavior = controller.systemBarsBehavior
@@ -110,23 +121,35 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
         modifier = Modifier
             .background(Color.Black)
             .fillMaxSize()
-            .pointerInput(Unit) {
-                detectTapGestures(onTap = {
-                    showBars = !showBars
-                })
-            }
     ) {
         val showUri = uri ?: if (uris.size == 1) uris.first() else null
         val state = rememberPagerState { uris.size }
 
+        LaunchedEffect(state.currentPage) {
+            userScrollEnabled = true
+        }
+
         if (showUri != null) {
-            UriImage(showUri)
+            UriImage(
+                uri = showUri,
+                onToggleBars = { showBars = !showBars },
+                onScaleChange = { userScrollEnabled = it <= 1f }
+            )
         } else if (uris.isNotEmpty()) {
             HorizontalPager(
                 modifier = Modifier.fillMaxSize(),
                 state = state,
-                pageContent = {
-                    UriImage(uris[it])
+                userScrollEnabled = userScrollEnabled,
+                pageContent = { index ->
+                    UriImage(
+                        uri = uris[index],
+                        onToggleBars = { showBars = !showBars },
+                        onScaleChange = { scale ->
+                            if (index == state.currentPage) {
+                                userScrollEnabled = scale <= 1f
+                            }
+                        }
+                    )
                 }
             )
         }
@@ -205,8 +228,13 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
     }
 }
 
+// 图片预览一些功能demo
 @Composable
-private fun UriImage(uri: String) {
+private fun UriImage(
+    uri: String,
+    onToggleBars: () -> Unit = {},
+    onScaleChange: (Float) -> Unit = {}
+) {
     val context = LocalContext.current
     val model = remember(uri) {
         ImageRequest.Builder(context).data(uri)
@@ -223,60 +251,168 @@ private fun UriImage(uri: String) {
     }
     val painter = rememberAsyncImagePainter(model)
     val state by painter.state.collectAsState()
-    val stateVal = state
-    when (stateVal) {
-        AsyncImagePainter.State.Empty -> {}
-        is AsyncImagePainter.State.Loading -> {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                CircularProgressIndicator(modifier = Modifier.size(40.dp))
-            }
-        }
 
-        is AsyncImagePainter.State.Success -> {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Image(
-                    painter = painter,
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxWidth(),
-                    contentScale = ContentScale.FillWidth,
-                    alignment = Alignment.Center,
-                )
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        when (val stateVal = state) {
+            AsyncImagePainter.State.Empty -> {}
+            is AsyncImagePainter.State.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .pointerInput(uri) { detectTapGestures(onTap = { onToggleBars() }) },
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(40.dp))
+                }
             }
-        }
 
-        is AsyncImagePainter.State.Error -> {
-            val reload = throttle { painter.restart() }
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Text(
-                    modifier = Modifier.pointerInput(Unit) {
-                        detectTapGestures(onTap = { reload() })
-                    },
-                    text = "加载失败, 点击重试",
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                stateVal.result.throwable.message?.let { msg ->
-                    Spacer(modifier = Modifier.height(8.dp))
+            is AsyncImagePainter.State.Success -> {
+                val scope = rememberCoroutineScope()
+                val scale = remember(uri) { Animatable(1f) }
+                val offsetX = remember(uri) { Animatable(0f) }
+                val offsetY = remember(uri) { Animatable(0f) }
+
+                BoxWithConstraints(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    val containerWidth = constraints.maxWidth.toFloat()
+                    val containerHeight = constraints.maxHeight.toFloat()
+
+                    val intrinsicSize = painter.intrinsicSize
+                    val imageHeight = remember(intrinsicSize, containerWidth) {
+                        if (intrinsicSize != Size.Unspecified && intrinsicSize.width > 0) {
+                            containerWidth * (intrinsicSize.height / intrinsicSize.width)
+                        } else {
+                            containerHeight
+                        }
+                    }
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .pointerInput(uri) {
+                                detectTapGestures(
+                                    onTap = { onToggleBars() },
+                                    onDoubleTap = { tapOffset ->
+                                        scope.launch {
+                                            // 双指缩放控制
+                                            if (scale.value > 1f) {
+                                                launch { scale.animateTo(1f) }
+                                                launch { offsetX.animateTo(0f) }
+                                                launch { offsetY.animateTo(0f) }
+                                                onScaleChange(1f)
+                                            } else {
+                                                // 双指缩放以两个手指开合你看到的上下手指中心点为中心的偏移量缩放控制计算，防止在中间缩放图片
+                                                val targetScale = 3f
+                                                val center = Offset(containerWidth / 2, containerHeight / 2)
+                                                var targetOffsetX = (center.x - tapOffset.x) * (targetScale - 1)
+                                                var targetOffsetY = (center.y - tapOffset.y) * (targetScale - 1)
+
+                                                val maxOffsetX = max(0f, (containerWidth * targetScale - containerWidth) / 2f)
+                                                val maxOffsetY = max(0f, (imageHeight * targetScale - containerHeight) / 2f)
+                                                targetOffsetX = targetOffsetX.coerceIn(-maxOffsetX, maxOffsetX)
+                                                targetOffsetY = targetOffsetY.coerceIn(-maxOffsetY, maxOffsetY)
+
+                                                launch { scale.animateTo(targetScale) }
+                                                launch { offsetX.animateTo(targetOffsetX) }
+                                                launch { offsetY.animateTo(targetOffsetY) }
+                                                onScaleChange(targetScale)
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+                            .pointerInput(uri, containerWidth, containerHeight, imageHeight) {
+                                awaitEachGesture {
+                                    awaitFirstDown(requireUnconsumed = false)
+                                    do {
+                                        val event = awaitPointerEvent()
+                                        val zoomChange = event.calculateZoom()
+                                        val panChange = event.calculatePan()
+
+                                        if (zoomChange != 1f) {
+                                            val targetScale = (scale.value * zoomChange).coerceIn(1f, 5f)
+                                            scope.launch {
+                                                scale.snapTo(targetScale)
+                                            }
+                                            onScaleChange(targetScale)
+                                            event.changes.forEach { it.consume() }
+                                        // 处理平移手势拖动
+                                        } else if (scale.value > 1f) {
+                                            val currentScale = scale.value
+                                            val maxOffsetX = max(0f, (containerWidth * currentScale - containerWidth) / 2f)
+                                            val maxOffsetY = max(0f, (imageHeight * currentScale - containerHeight) / 2f)
+
+                                            val atLeftEdge = offsetX.value >= maxOffsetX
+                                            val atRightEdge = offsetX.value <= -maxOffsetX
+
+                                            val isHorizontalPan = abs(panChange.x) > abs(panChange.y)
+                                            val isScrollingOut = (panChange.x > 0 && atLeftEdge) || (panChange.x < 0 && atRightEdge)
+
+                                            if (isHorizontalPan && isScrollingOut) {
+                                                // 让 HorizontalPager 处理
+                                            } else {
+                                                scope.launch {
+                                                    offsetX.snapTo((offsetX.value + panChange.x).coerceIn(-maxOffsetX, maxOffsetX))
+                                                    offsetY.snapTo((offsetY.value + panChange.y).coerceIn(-maxOffsetY, maxOffsetY))
+                                                }
+                                                event.changes.forEach { it.consume() }
+                                            }
+                                        }
+                                    } while (event.changes.any { it.pressed })
+                                }
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        // 渲染图片
+                        Image(
+                            painter = painter,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .graphicsLayer(
+                                    scaleX = scale.value,
+                                    scaleY = scale.value,
+                                    translationX = offsetX.value,
+                                    translationY = offsetY.value
+                                )
+                                .fillMaxWidth(),
+                            contentScale = ContentScale.FillWidth
+                        )
+                    }
+                }
+            }
+
+            is AsyncImagePainter.State.Error -> {
+                val reload = throttle { painter.restart() }
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .pointerInput(uri) { detectTapGestures(onTap = { onToggleBars() }) },
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
                     Text(
-                        text = msg,
-                        color = MaterialTheme.colorScheme.outline,
-                        style = MaterialTheme.typography.labelSmall,
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        textAlign = TextAlign.Center
+                        modifier = Modifier.pointerInput(uri) {
+                            detectTapGestures(onTap = { reload() })
+                        },
+                        text = "加载失败, 点击重试",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium
                     )
+                    stateVal.result.throwable.message?.let { msg ->
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = msg,
+                            color = MaterialTheme.colorScheme.outline,
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            textAlign = TextAlign.Center
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -6,8 +6,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.AnimationConstants.DefaultDurationMillis
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -58,13 +56,13 @@ import coil3.compose.AsyncImagePainter
 import coil3.compose.rememberAsyncImagePainter
 import coil3.decode.Decoder
 import coil3.fetch.Fetcher
+import coil3.imageLoader
 import coil3.request.CachePolicy
 import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.Options
 import coil3.request.SuccessResult
 import coil3.request.crossfade
-import coil3.imageLoader
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -117,16 +115,26 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
     val singleItem = previewItems.singleOrNull()
     val pagerState = rememberPagerState(pageCount = { previewItems.size.coerceAtLeast(1) })
 
-    // 这个页面需要接近相册页的沉浸式效果，因此进入时隐藏状态栏，离开时恢复原设置。
-    DisposableEffect(Unit) {
-        val controller = WindowCompat.getInsetsController(context.window, context.window.decorView)
+    val controller = remember {
+        WindowCompat.getInsetsController(context.window, context.window.decorView)
+    }
+    DisposableEffect(null) {
         val oldBehavior = controller.systemBarsBehavior
+        val oldLight = controller.isAppearanceLightStatusBars
         controller.systemBarsBehavior =
             WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        controller.hide(WindowInsetsCompat.Type.statusBars())
+        controller.isAppearanceLightStatusBars = false
         onDispose {
             controller.systemBarsBehavior = oldBehavior
+            controller.isAppearanceLightStatusBars = oldLight
             controller.show(WindowInsetsCompat.Type.statusBars())
+        }
+    }
+    LaunchedEffect(showBars) {
+        if (showBars) {
+            controller.show(WindowInsetsCompat.Type.statusBars())
+        } else {
+            controller.hide(WindowInsetsCompat.Type.statusBars())
         }
     }
 
@@ -153,7 +161,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
 
     Box(
         modifier = Modifier
-            .background(MaterialTheme.colorScheme.background)
+            .background(Color.Black)
             .fillMaxSize()
     ) {
         when {
@@ -180,14 +188,15 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
 
         AnimatedVisibility(
             visible = showBars,
-            enter = fadeIn() + slideInVertically(initialOffsetY = { -it }),
-            exit = fadeOut() + slideOutVertically(targetOffsetY = { -it }),
+            enter = fadeIn(),
+            exit = fadeOut(),
             modifier = Modifier
                 .zIndex(1f)
                 .fillMaxWidth()
         ) {
             Column {
-                val currentPreviewItem = singleItem ?: previewItems.getOrNull(pagerState.currentPage)
+                val currentPreviewItem =
+                    singleItem ?: previewItems.getOrNull(pagerState.currentPage)
                 val currentUri = currentPreviewItem?.uri
                 PerfTopAppBar(
                     modifier = Modifier.background(Color.Black.copy(alpha = 0.5f)),
@@ -462,7 +471,7 @@ private fun ZoomableImageContent(
                     state = zoomableState,
                     onClick = { onToggleBars() },
                 ),
-            contentScale = ContentScale.Fit,
+            contentScale = ContentScale.Inside,
             alignment = Alignment.Center,
         )
     }

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -54,44 +54,36 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation3.runtime.NavKey
 import coil3.EventListener
-import coil3.ImageLoader
 import coil3.compose.AsyncImagePainter
 import coil3.compose.rememberAsyncImagePainter
 import coil3.decode.Decoder
-import coil3.disk.DiskCache
 import coil3.fetch.Fetcher
-import coil3.gif.AnimatedImageDecoder
-import coil3.gif.GifDecoder
-import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.CachePolicy
 import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.Options
 import coil3.request.SuccessResult
 import coil3.request.crossfade
+import coil3.imageLoader
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.Serializable
 import li.songe.gkd.MainActivity
-import li.songe.gkd.app
 import li.songe.gkd.ui.component.PerfIcon
 import li.songe.gkd.ui.component.PerfIconButton
 import li.songe.gkd.ui.component.PerfTopAppBar
 import li.songe.gkd.ui.share.LocalMainViewModel
-import li.songe.gkd.util.AndroidTarget
-import li.songe.gkd.util.coilCacheDir
 import li.songe.gkd.util.throttle
 import me.saket.telephoto.zoomable.ZoomableContentLocation
 import me.saket.telephoto.zoomable.rememberZoomableState
 import me.saket.telephoto.zoomable.zoomable
-import okhttp3.OkHttpClient
-import okio.Path.Companion.toOkioPath
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 
 @Serializable
 data class ImagePreviewItem(
     val uri: String,
     val title: String? = null,
+    val titles: List<String> = emptyList(),
 )
 
 @Serializable
@@ -106,6 +98,7 @@ data class ImagePreviewRoute(
 fun ImagePreviewPage(route: ImagePreviewRoute) {
     val mainVm = LocalMainViewModel.current
     val context = LocalActivity.current as MainActivity
+    val imageLoader = context.imageLoader
     var showBars by remember { mutableStateOf(true) }
 
     // 路由同时兼容旧的 uri/uris 和新的 items，预览页内部统一按图片项处理。
@@ -137,19 +130,24 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
         }
     }
 
-    // 规则组示例图通常会连续查看，因此进入预览后直接预加载组内所有图片
+    // 规则组示例图会连续横滑，但预取并发限制在 2，避免与首图显示请求抢带宽。
     LaunchedEffect(previewUris) {
         if (previewUris.size <= 1) return@LaunchedEffect
         previewUris
             .drop(1)
             .filter(URLUtil::isNetworkUrl)
-            .forEach { preloadUri ->
-                imageLoader.enqueue(
-                    buildPreviewImageRequest(
-                        context = context,
-                        uri = preloadUri,
-                    )
-                )
+            .chunked(2)
+            .forEach { uriBatch ->
+                uriBatch.map { preloadUri ->
+                    async {
+                        imageLoader.execute(
+                            buildPreviewImageRequest(
+                                context = context,
+                                uri = preloadUri,
+                            )
+                        )
+                    }
+                }.awaitAll()
             }
     }
 
@@ -202,7 +200,8 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                     },
                     title = {
                         val baseTitle = route.title?.takeIf { it.isNotBlank() }
-                        val itemTitle = currentPreviewItem?.title
+                        val itemTitle = currentPreviewItem
+                            ?.let(::buildPreviewSubtitle)
                             ?.takeIf { it.isNotBlank() && it != baseTitle }
                         when {
                             baseTitle != null && itemTitle != null -> {
@@ -304,61 +303,54 @@ private fun UriImage(
     onToggleBars: () -> Unit = {},
 ) {
     val context = LocalContext.current
+    val imageLoader = context.imageLoader
     val isNetworkImage = remember(uri) { URLUtil.isNetworkUrl(uri) }
     val phaseTextFlow = remember(uri) { MutableStateFlow<String?>(null) }
     val phaseText by phaseTextFlow.collectAsState()
-
-    // 预览页添加请求阶段文字。
-    val requestImageLoader = remember(uri, isNetworkImage) {
-        imageLoader.newBuilder()
-            .eventListenerFactory {
-                object : EventListener() {
-                    override fun onStart(request: ImageRequest) {
-                        phaseTextFlow.value = "请求中"
-                    }
-
-                    override fun fetchStart(
-                        request: ImageRequest,
-                        fetcher: Fetcher,
-                        options: Options,
-                    ) {
-                        phaseTextFlow.value = if (isNetworkImage) "下载中" else "读取中"
-                    }
-
-                    override fun decodeStart(
-                        request: ImageRequest,
-                        decoder: Decoder,
-                        options: Options,
-                    ) {
-                        phaseTextFlow.value = "解码中"
-                    }
-
-                    override fun onSuccess(request: ImageRequest, result: SuccessResult) {
-                        phaseTextFlow.value = null
-                    }
-
-                    override fun onError(request: ImageRequest, result: ErrorResult) {
-                        phaseTextFlow.value = null
-                    }
-
-                    override fun onCancel(request: ImageRequest) {
-                        phaseTextFlow.value = null
-                    }
-                }
-            }
-            .build()
-    }
 
     // 手势层切至 Telephoto，loading / error 还是使用 AsyncImagePainter.State 统一驱动。
     val model = remember(uri) {
         buildPreviewImageRequest(
             context = context,
             uri = uri,
+            listener = object : EventListener() {
+                override fun onStart(request: ImageRequest) {
+                    phaseTextFlow.value = "请求中"
+                }
+
+                override fun fetchStart(
+                    request: ImageRequest,
+                    fetcher: Fetcher,
+                    options: Options,
+                ) {
+                    phaseTextFlow.value = if (isNetworkImage) "下载中" else "读取中"
+                }
+
+                override fun decodeStart(
+                    request: ImageRequest,
+                    decoder: Decoder,
+                    options: Options,
+                ) {
+                    phaseTextFlow.value = "解码中"
+                }
+
+                override fun onSuccess(request: ImageRequest, result: SuccessResult) {
+                    phaseTextFlow.value = null
+                }
+
+                override fun onError(request: ImageRequest, result: ErrorResult) {
+                    phaseTextFlow.value = null
+                }
+
+                override fun onCancel(request: ImageRequest) {
+                    phaseTextFlow.value = null
+                }
+            }
         )
     }
     val painter = rememberAsyncImagePainter(
         model = model,
-        imageLoader = requestImageLoader,
+        imageLoader = imageLoader,
     )
     val state by painter.state.collectAsState()
 
@@ -479,10 +471,12 @@ private fun ZoomableImageContent(
 private fun buildPreviewImageRequest(
     context: android.content.Context,
     uri: String,
+    listener: EventListener? = null,
 ): ImageRequest {
     return ImageRequest.Builder(context)
         .data(uri)
         .crossfade(DefaultDurationMillis)
+        .listener(listener)
         .run {
             if (URLUtil.isNetworkUrl(uri)) {
                 this
@@ -494,31 +488,12 @@ private fun buildPreviewImageRequest(
         .build()
 }
 
-private val imageLoader by lazy {
-    ImageLoader.Builder(app)
-        .diskCache {
-            DiskCache.Builder()
-                .directory(coilCacheDir.toOkioPath())
-                .maxSizePercent(0.1)
-                .build()
-        }
-        .components {
-            if (AndroidTarget.P) {
-                add(AnimatedImageDecoder.Factory())
-            } else {
-                add(GifDecoder.Factory())
-            }
-            add(
-                OkHttpNetworkFetcherFactory(
-                    callFactory = {
-                        OkHttpClient.Builder()
-                            .connectTimeout(30.seconds.toJavaDuration())
-                            .readTimeout(30.seconds.toJavaDuration())
-                            .writeTimeout(30.seconds.toJavaDuration())
-                            .build()
-                    }
-                )
-            )
-        }
-        .build()
+private fun buildPreviewSubtitle(item: ImagePreviewItem): String? {
+    val titles = buildList {
+        item.title?.takeIf { it.isNotBlank() }?.let(::add)
+        item.titles
+            .mapNotNull { it.takeIf(String::isNotBlank) }
+            .forEach(::add)
+    }.distinct()
+    return titles.takeIf { it.isNotEmpty() }?.joinToString(" / ")
 }

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -14,20 +14,22 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -40,13 +42,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -108,7 +108,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
     }
     Box(
         modifier = Modifier
-            .background(MaterialTheme.colorScheme.background)
+            .background(Color.Black)
             .fillMaxSize()
             .pointerInput(Unit) {
                 detectTapGestures(onTap = {
@@ -118,6 +118,19 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
     ) {
         val showUri = uri ?: if (uris.size == 1) uris.first() else null
         val state = rememberPagerState { uris.size }
+
+        if (showUri != null) {
+            UriImage(showUri)
+        } else if (uris.isNotEmpty()) {
+            HorizontalPager(
+                modifier = Modifier.fillMaxSize(),
+                state = state,
+                pageContent = {
+                    UriImage(uris[it])
+                }
+            )
+        }
+
         AnimatedVisibility(
             visible = showBars,
             enter = fadeIn() + slideInVertically(initialOffsetY = { -it }),
@@ -126,79 +139,63 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
                 .zIndex(1f)
                 .fillMaxWidth()
         ) {
-            PerfTopAppBar(
-                navigationIcon = {
-                    PerfIconButton(imageVector = PerfIcon.ArrowBack, onClick = {
-                        mainVm.popPage()
-                    })
-                },
-                title = {
-                    if (title != null) {
-                        Text(
-                            text = title,
-                            maxLines = 1,
-                            softWrap = false,
-                            overflow = TextOverflow.MiddleEllipsis,
-                            style = MaterialTheme.typography.titleLarge.copy(
-                                color = MaterialTheme.colorScheme.onBackground,
-                                shadow = Shadow(
-                                    color = Color.Black.copy(alpha = 0.7f),
-                                    blurRadius = with(LocalDensity.current) { 2.dp.toPx() },
-                                    offset = with(LocalDensity.current) {
-                                        Offset(1.dp.toPx(), 1.dp.toPx())
-                                    }
+            Column {
+                PerfTopAppBar(
+                    modifier = Modifier.background(Color.Black.copy(alpha = 0.5f)),
+                    navigationIcon = {
+                        PerfIconButton(
+                            imageVector = PerfIcon.ArrowBack,
+                            onClick = { mainVm.popPage() },
+                            colors = IconButtonDefaults.iconButtonColors(contentColor = Color.White)
+                        )
+                    },
+                    title = {
+                        if (title != null) {
+                            Text(
+                                text = title,
+                                maxLines = 1,
+                                softWrap = false,
+                                overflow = TextOverflow.MiddleEllipsis,
+                                style = MaterialTheme.typography.titleLarge.copy(
+                                    color = Color.White,
+                                    fontWeight = FontWeight.Medium
                                 )
                             )
-                        )
-                    }
-                },
-                actions = {
-                    val currentUri = showUri ?: uris.getOrNull(state.currentPage)
-                    if (currentUri != null && URLUtil.isNetworkUrl(currentUri)) {
-                        PerfIconButton(imageVector = PerfIcon.OpenInNew, onClick = throttle(fn = {
-                            mainVm.openUrl(currentUri)
-                        }))
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background.copy(alpha = 0.1f)
+                        }
+                    },
+                    actions = {
+                        val currentUri = showUri ?: uris.getOrNull(state.currentPage)
+                        if (currentUri != null && URLUtil.isNetworkUrl(currentUri)) {
+                            PerfIconButton(
+                                imageVector = PerfIcon.OpenInNew,
+                                onClick = throttle(fn = { mainVm.openUrl(currentUri) }),
+                                colors = IconButtonDefaults.iconButtonColors(contentColor = Color.White)
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Color.Transparent,
+                        navigationIconContentColor = Color.White,
+                        titleContentColor = Color.White,
+                        actionIconContentColor = Color.White
+                    )
                 )
-            )
-        }
-        if (showUri != null) {
-            UriImage(showUri)
-        } else if (uris.isNotEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize()
-            ) {
-                HorizontalPager(
-                    modifier = Modifier.fillMaxSize(),
-                    state = state,
-                    pageContent = {
-                        UriImage(uris[it])
-                    }
-                )
-                AnimatedVisibility(
-                    visible = showBars,
-                    enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
-                    exit = fadeOut() + slideOutVertically(targetOffsetY = { it }),
-                    modifier = Modifier.align(Alignment.BottomCenter)
-                ) {
-                    val navBarsPadding = WindowInsets.navigationBars.asPaddingValues()
+
+                if (uris.size > 1) {
                     Box(
-                        Modifier
+                        modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = 64.dp + navBarsPadding.calculateBottomPadding()),
-                        contentAlignment = Alignment.BottomCenter
+                            .padding(top = 12.dp),
+                        contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = "${state.currentPage + 1}/${uris.size}",
-                            style = MaterialTheme.typography.titleLarge.copy(
-                                color = MaterialTheme.colorScheme.onPrimary,
-                                shadow = Shadow(
-                                    color = Color.Black.copy(alpha = 0.8f),
-                                    blurRadius = with(LocalDensity.current) { 3.dp.toPx() }
-                                )
+                            text = "${state.currentPage + 1} / ${uris.size}",
+                            modifier = Modifier
+                                .background(Color.Black.copy(alpha = 0.5f), CircleShape)
+                                .padding(horizontal = 12.dp, vertical = 4.dp),
+                            color = Color.White,
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                fontWeight = FontWeight.Bold
                             )
                         )
                     }

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -118,7 +118,7 @@ fun ImagePreviewPage(route: ImagePreviewRoute) {
 
     Box(
         modifier = Modifier
-            .background(Color.Black)
+            .background(MaterialTheme.colorScheme.background)
             .fillMaxSize()
     ) {
         when {
@@ -327,18 +327,26 @@ private fun ZoomableImageContent(
         }
     }
 
-    Image(
-        painter = painter,
-        contentDescription = null,
+    // 限制图片成功状态下的深色画布背景，防止非必要全局黑色背景不跟随主题
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .zoomable(
-                state = zoomableState,
-                onClick = { onToggleBars() },
-            ),
-        contentScale = ContentScale.Fit,
-        alignment = Alignment.Center,
-    )
+            .background(Color.Black),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = painter,
+            contentDescription = null,
+            modifier = Modifier
+                .fillMaxSize()
+                .zoomable(
+                    state = zoomableState,
+                    onClick = { onToggleBars() },
+                ),
+            contentScale = ContentScale.Fit,
+            alignment = Alignment.Center,
+        )
+    }
 }
 
 private val imageLoader by lazy {

--- a/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/ImagePreviewPage.kt
@@ -53,16 +53,23 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation3.runtime.NavKey
+import coil3.EventListener
 import coil3.ImageLoader
 import coil3.compose.AsyncImagePainter
 import coil3.compose.rememberAsyncImagePainter
+import coil3.decode.Decoder
 import coil3.disk.DiskCache
+import coil3.fetch.Fetcher
 import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.CachePolicy
+import coil3.request.ErrorResult
 import coil3.request.ImageRequest
+import coil3.request.Options
+import coil3.request.SuccessResult
 import coil3.request.crossfade
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.Serializable
 import li.songe.gkd.MainActivity
 import li.songe.gkd.app
@@ -223,13 +230,58 @@ private fun UriImage(
     onToggleBars: () -> Unit = {},
 ) {
     val context = LocalContext.current
-    // 手势层切至Telephoto,loading,error还是使用AsyncImagePainter.State统一驱动
+    val isNetworkImage = remember(uri) { URLUtil.isNetworkUrl(uri) }
+    val phaseTextFlow = remember(uri) { MutableStateFlow<String?>(null) }
+    val phaseText by phaseTextFlow.collectAsState()
+
+    // 预览页添加请求阶段文字。
+    val requestImageLoader = remember(uri, isNetworkImage) {
+        imageLoader.newBuilder()
+            .eventListenerFactory {
+                object : EventListener() {
+                    override fun onStart(request: ImageRequest) {
+                        phaseTextFlow.value = "请求中"
+                    }
+
+                    override fun fetchStart(
+                        request: ImageRequest,
+                        fetcher: Fetcher,
+                        options: Options,
+                    ) {
+                        phaseTextFlow.value = if (isNetworkImage) "下载中" else "读取中"
+                    }
+
+                    override fun decodeStart(
+                        request: ImageRequest,
+                        decoder: Decoder,
+                        options: Options,
+                    ) {
+                        phaseTextFlow.value = "解码中"
+                    }
+
+                    override fun onSuccess(request: ImageRequest, result: SuccessResult) {
+                        phaseTextFlow.value = null
+                    }
+
+                    override fun onError(request: ImageRequest, result: ErrorResult) {
+                        phaseTextFlow.value = null
+                    }
+
+                    override fun onCancel(request: ImageRequest) {
+                        phaseTextFlow.value = null
+                    }
+                }
+            }
+            .build()
+    }
+
+    // 手势层切至 Telephoto，loading / error 还是使用 AsyncImagePainter.State 统一驱动。
     val model = remember(uri) {
         ImageRequest.Builder(context)
             .data(uri)
             .crossfade(DefaultDurationMillis)
             .run {
-                if (URLUtil.isNetworkUrl(uri)) {
+                if (isNetworkImage) {
                     this
                 } else {
                     diskCachePolicy(CachePolicy.DISABLED)
@@ -237,11 +289,11 @@ private fun UriImage(
                 }
             }
             .build()
-            .apply {
-                imageLoader.enqueue(this)
-            }
     }
-    val painter = rememberAsyncImagePainter(model)
+    val painter = rememberAsyncImagePainter(
+        model = model,
+        imageLoader = requestImageLoader,
+    )
     val state by painter.state.collectAsState()
 
     Box(
@@ -252,15 +304,24 @@ private fun UriImage(
             AsyncImagePainter.State.Empty -> Unit
 
             is AsyncImagePainter.State.Loading -> {
-                Box(
+                Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .pointerInput(uri) {
                             detectTapGestures(onTap = { onToggleBars() })
                         },
-                    contentAlignment = Alignment.Center
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
                 ) {
                     CircularProgressIndicator(modifier = Modifier.size(40.dp))
+                    phaseText?.let { text ->
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = text,
+                            color = MaterialTheme.colorScheme.outline,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/li/songe/gkd/ui/component/RuleGroupDialog.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/component/RuleGroupDialog.kt
@@ -188,31 +188,34 @@ fun RuleGroupDialog(
 
 // 规则组示例图需要保留“图片属于哪个子规则”的上下文，预览页才能显示更具体的标题。
 private fun buildRuleGroupPreviewItems(group: RawSubscription.RawGroupProps): List<ImagePreviewItem> {
-    val seenUris = linkedSetOf<String>()
-    return buildList {
-        group.exampleUrls.orEmpty().forEach { uri ->
-            if (seenUris.add(uri)) {
-                add(
-                    ImagePreviewItem(
-                        uri = uri,
-                        title = group.name,
-                    )
-                )
-            }
+    val uriTitlesMap = linkedMapOf<String, LinkedHashSet<String>>()
+
+    fun addPreviewItem(uri: String, title: String?) {
+        val titles = uriTitlesMap.getOrPut(uri) { linkedSetOf() }
+        title?.takeIf { it.isNotBlank() }?.let(titles::add)
+    }
+
+    group.exampleUrls.orEmpty().forEach { uri ->
+        addPreviewItem(
+            uri = uri,
+            title = group.name,
+        )
+    }
+    group.rules.forEach { rule ->
+        val ruleTitle = buildRulePreviewTitle(rule)
+        rule.exampleUrls.orEmpty().forEach { uri ->
+            addPreviewItem(
+                uri = uri,
+                title = ruleTitle,
+            )
         }
-        group.rules.forEach { rule ->
-            val ruleTitle = buildRulePreviewTitle(rule)
-            rule.exampleUrls.orEmpty().forEach { uri ->
-                if (seenUris.add(uri)) {
-                    add(
-                        ImagePreviewItem(
-                            uri = uri,
-                            title = ruleTitle,
-                        )
-                    )
-                }
-            }
-        }
+    }
+
+    return uriTitlesMap.map { (uri, titles) ->
+        ImagePreviewItem(
+            uri = uri,
+            titles = titles.toList(),
+        )
     }
 }
 

--- a/app/src/main/kotlin/li/songe/gkd/ui/component/RuleGroupDialog.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/component/RuleGroupDialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import li.songe.gkd.data.RawSubscription
+import li.songe.gkd.ui.ImagePreviewItem
 import li.songe.gkd.ui.ImagePreviewRoute
 import li.songe.gkd.ui.SubsAppGroupListRoute
 import li.songe.gkd.ui.SubsGlobalGroupListRoute
@@ -152,7 +153,7 @@ fun RuleGroupDialog(
                         mainVm.navigatePage(
                             ImagePreviewRoute(
                                 title = group.name,
-                                uris = group.allExampleUrls,
+                                items = buildRuleGroupPreviewItems(group),
                             )
                         )
                     })
@@ -183,4 +184,43 @@ fun RuleGroupDialog(
             }
         },
     )
+}
+
+// 规则组示例图需要保留“图片属于哪个子规则”的上下文，预览页才能显示更具体的标题。
+private fun buildRuleGroupPreviewItems(group: RawSubscription.RawGroupProps): List<ImagePreviewItem> {
+    val seenUris = linkedSetOf<String>()
+    return buildList {
+        group.exampleUrls.orEmpty().forEach { uri ->
+            if (seenUris.add(uri)) {
+                add(
+                    ImagePreviewItem(
+                        uri = uri,
+                        title = group.name,
+                    )
+                )
+            }
+        }
+        group.rules.forEach { rule ->
+            val ruleTitle = buildRulePreviewTitle(rule)
+            rule.exampleUrls.orEmpty().forEach { uri ->
+                if (seenUris.add(uri)) {
+                    add(
+                        ImagePreviewItem(
+                            uri = uri,
+                            title = ruleTitle,
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun buildRulePreviewTitle(rule: RawSubscription.RawRuleProps): String? {
+    return when {
+        !rule.name.isNullOrBlank() -> rule.name
+        rule.key != null -> "key=${rule.key}"
+        !rule.preKeys.isNullOrEmpty() -> "preKeys=${(rule.preKeys as Iterable<Any?>).joinToString(",")}"
+        else -> null
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ paging = "3.4.2"
 ktor = "3.4.2"
 atomicfu = "0.32.1"
 coil = "3.4.0"
+telephoto = "0.18.0"
 refine = "4.4.0"
 shizuku = "13.1.5"
 loc = "0.5.4"
@@ -65,6 +66,7 @@ lsposed-hiddenapibypass = "org.lsposed.hiddenapibypass:hiddenapibypass:6.1"
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
+telephoto-zoomable = { module = "me.saket.telephoto:zoomable", version.ref = "telephoto" }
 loc-annotation = { module = "li.songe.loc:loc-annotation", version.ref = "loc" }
 reorderable = "sh.calvin.reorderable:reorderable:3.0.0"
 exp4j = "net.objecthunter:exp4j:0.4.8"


### PR DESCRIPTION
# 目前图片查看加阴影还是存在图片色与字色相似难以分辨问题
## 如图
![Screenshot_20260329_085433](https://github.com/user-attachments/assets/8b02fcce-86cb-45ae-8cfe-c162aa810043)

### 具体做了
 - 解决字色相似难以分辨问题
 - 标题栏可点击收起
 - 图片可操作放大查看(demo待优化)
 - 图片加载失败显示具体原因

 ### 目前问题
  1. 实现操作逻辑造轮子代码量太多感觉不好维护，可否使用`Telephoto`组件库以减少代码量，方便后期维护
  2. 图片预览功能抽离可以给其他场景复用，如快照-查看图片，而不用重复再写一遍(待定)
  
## 目前效果

<img src="https://github.com/user-attachments/assets/0aa16fa4-bd91-4c1d-9143-fc9f4a0cebaa" width="50%">

https://github.com/user-attachments/assets/4346a377-132b-4aa7-b3c9-2a3b8ef5a897

### TODO
  - [x] 字色相似难以分辨问题
  - [x] 标题栏可点击收起
  - [x] 图片可操作放大查看
  - [x] 加载图片显示状态信息
