### PR TITLE
perf: Apk Sign fullback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,12 +95,6 @@ android {
         resValues = true
     }
 
-    // ------------------------------------------------------------------------------
-    // 签名配置管理 (Signing Configurations)
-    // ------------------------------------------------------------------------------
-
-    // 1. GKD 渠道签名：优先读取 GKD_STORE_FILE 等环境变量/属性
-    // 若缺失签名信息（如本地环境未配置），则回退至 debug 签名以防止构建 Evaluation 阶段崩溃
     val gkdSigningConfig = if (project.hasProperty("GKD_STORE_FILE")) {
         signingConfigs.create("gkd") {
             storeFile = file(project.properties["GKD_STORE_FILE"] as String)
@@ -109,11 +103,9 @@ android {
             keyPassword = project.findProperty("GKD_KEY_PASSWORD")?.toString()
         }
     } else {
-        // Fallback: 缺失变量时回退使用 debug 签名（满足本地测试/test需求）
         signingConfigs.getByName("debug")
     }
 
-    // 2. Play 渠道签名
     val playSigningConfig = if (project.hasProperty("PLAY_STORE_FILE")) {
         signingConfigs.create("play") {
             storeFile = file(project.properties["PLAY_STORE_FILE"].toString())


### PR DESCRIPTION
## 目前问题
### 在Gradle Sync时候如果电脑本地环境没有配置签名变量情况下会出现错误
<details><summary>展开截图</summary>
<p>

<img width="1598" height="281" alt="PixPin_2026-04-04_12-35-58" src="https://github.com/user-attachments/assets/a9aa1944-5885-4e8c-9240-24f5f5214eb4" />

</p>
</details> 

## ci显示信息优化
### 如何快速查看使用哪种签名？(计划如何实现ing……)
#### 如图举例
<img width="1325" height="822" alt="图片" src="https://github.com/user-attachments/assets/8753a40f-a914-4aa9-b08c-551f72045637" />

TODO
- [x] 签名fullback回退机制
- [ ] ci显示使用哪种签名