### PR TITLE
refactor: SnapshotPage UI/Function dev2

### DIFF
--- a/app/src/main/kotlin/li/songe/gkd/ui/SnapshotPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/SnapshotPage.kt
@@ -3,19 +3,28 @@ package li.songe.gkd.ui
 import android.graphics.BitmapFactory
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items as gridItems
+import androidx.compose.foundation.lazy.items as lazyItems
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
@@ -23,23 +32,30 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavKey
+import coil3.compose.AsyncImage
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -48,23 +64,14 @@ import li.songe.gkd.data.Snapshot
 import li.songe.gkd.db.DbSet
 import li.songe.gkd.permission.canWriteExternalStorage
 import li.songe.gkd.permission.requiredPermission
+import li.songe.gkd.ui.component.AppIcon
 import li.songe.gkd.ui.component.EmptyText
-import li.songe.gkd.ui.component.FixedTimeText
-import li.songe.gkd.ui.component.LocalNumberCharWidth
 import li.songe.gkd.ui.component.PerfIcon
 import li.songe.gkd.ui.component.PerfIconButton
 import li.songe.gkd.ui.component.PerfTopAppBar
-import li.songe.gkd.ui.component.animateListItem
-import li.songe.gkd.ui.component.measureNumberTextWidth
-import li.songe.gkd.ui.component.useListScrollState
 import li.songe.gkd.ui.component.waitResult
-import li.songe.gkd.ui.share.ListPlaceholder
 import li.songe.gkd.ui.share.LocalMainViewModel
 import li.songe.gkd.ui.share.noRippleClickable
-import li.songe.gkd.ui.style.EmptyHeight
-import li.songe.gkd.ui.style.itemHorizontalPadding
-import li.songe.gkd.ui.style.itemVerticalPadding
-import li.songe.gkd.ui.style.scaffoldPadding
 import li.songe.gkd.util.IMPORT_SHORT_URL
 import li.songe.gkd.util.ImageUtils
 import li.songe.gkd.util.SnapshotExt
@@ -80,40 +87,51 @@ import li.songe.gkd.util.toast
 @Serializable
 data object SnapshotPageRoute : NavKey
 
+private val SnapshotSidebarWidth = 72.dp
+private val SnapshotSidebarPadding = 8.dp
+private val SnapshotGridSpacing = 12.dp
+private val SnapshotGridPadding = 16.dp
+private val SnapshotGridMinCardWidth = 136.dp
+
 @Composable
 fun SnapshotPage() {
-    val context = LocalActivity.current as MainActivity
     val mainVm = LocalMainViewModel.current
     val colorScheme = MaterialTheme.colorScheme
     val vm = viewModel<SnapshotVm>()
 
     val firstLoading by vm.firstLoadingFlow.collectAsState()
-    val snapshots by vm.snapshotsState.collectAsState()
-    var selectedSnapshot by remember { mutableStateOf<Snapshot?>(null) }
-    val resetKey = rememberSaveable { mutableIntStateOf(0) }
-    val (scrollBehavior, listState) = useListScrollState(
-        resetKey,
-        snapshots.isEmpty(),
-        firstLoading,
-    )
-    val timeTextWidth = measureNumberTextWidth(MaterialTheme.typography.bodySmall)
+    val appGroups by vm.appGroupsState.collectAsState()
+    val selectedSnapshotState = remember { mutableStateOf<Snapshot?>(null) }
+    val previewSnapshotState = remember { mutableStateOf<Snapshot?>(null) }
+    val selectedAppIdState = rememberSaveable { mutableStateOf<String?>(null) }
 
-    Scaffold(modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection), topBar = {
+    // 侧栏只有 App 维度，当前选中项若失效则自动回退到“最新快照所属 App”。
+    val selectedGroup = remember(appGroups, selectedAppIdState.value) {
+        appGroups.firstOrNull { it.appId == selectedAppIdState.value } ?: appGroups.firstOrNull()
+    }
+
+    Scaffold(topBar = {
         PerfTopAppBar(
-            scrollBehavior = scrollBehavior,
             navigationIcon = {
-                PerfIconButton(imageVector = PerfIcon.ArrowBack, onClick = {
-                    mainVm.popPage()
-                })
+                PerfIconButton(imageVector = PerfIcon.ArrowBack, onClick = { mainVm.popPage() })
             },
             title = {
-                Text(
-                    text = "快照记录",
-                    modifier = Modifier.noRippleClickable { resetKey.intValue++ },
-                )
+                // 顶栏保留页面名，同时补充当前 App 名称，避免侧栏只有图标时用户失去上下文。
+                Column {
+                    Text(text = "快照记录")
+                    selectedGroup?.let { group ->
+                        Text(
+                            text = group.appName,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
             },
             actions = {
-                if (snapshots.isNotEmpty()) {
+                if (appGroups.isNotEmpty()) {
                     PerfIconButton(
                         imageVector = PerfIcon.Delete,
                         onClick = throttle(fn = vm.viewModelScope.launchAsFn(Dispatchers.IO) {
@@ -122,179 +140,106 @@ fun SnapshotPage() {
                                 text = "确定删除所有快照记录?",
                                 error = true,
                             )
-                            snapshots.forEach { s ->
-                                SnapshotExt.removeSnapshot(s.id)
+                            appGroups.flatMap { it.snapshots }.forEach { snapshot ->
+                                SnapshotExt.removeSnapshot(snapshot.id)
                             }
                             DbSet.snapshotDao.deleteAll()
                         })
                     )
                 }
-            })
-    }, content = { contentPadding ->
-        CompositionLocalProvider(
-            LocalNumberCharWidth provides timeTextWidth
-        ) {
-            LazyColumn(
-                modifier = Modifier.scaffoldPadding(contentPadding),
-                state = listState,
-            ) {
-                items(snapshots, { it.id }) { snapshot ->
-                    SnapshotCard(
-                        modifier = Modifier.animateListItem(),
-                        snapshot = snapshot,
-                        onClick = {
-                            selectedSnapshot = snapshot
-                        }
-                    )
+            }
+        )
+    }) { contentPadding ->
+        when {
+            appGroups.isEmpty() && !firstLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(contentPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    EmptyText(text = "暂无数据")
                 }
-                item(ListPlaceholder.KEY, ListPlaceholder.TYPE) {
-                    Spacer(modifier = Modifier.height(EmptyHeight))
-                    if (snapshots.isEmpty() && !firstLoading) {
-                        EmptyText(text = "暂无数据")
-                    }
+            }
+
+            selectedGroup != null -> {
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(contentPadding)
+                ) {
+                    SnapshotSidebar(
+                        groups = appGroups,
+                        selectedAppId = selectedGroup.appId,
+                        onSelectApp = { appId -> selectedAppIdState.value = appId },
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .width(1.dp)
+                            .background(colorScheme.outlineVariant.copy(alpha = 0.35f))
+                    )
+                    SnapshotGrid(
+                        modifier = Modifier.weight(1f),
+                        group = selectedGroup,
+                        onClickSnapshot = { snapshot -> selectedSnapshotState.value = snapshot },
+                        onPreviewSnapshot = { snapshot -> previewSnapshotState.value = snapshot },
+                    )
                 }
             }
         }
-    })
+    }
 
-    selectedSnapshot?.let { snapshotVal ->
-        Dialog(onDismissRequest = { selectedSnapshot = null }) {
-            Card(
+    selectedSnapshotState.value?.let { snapshot ->
+        SnapshotActionDialog(
+            snapshot = snapshot,
+            onDismissRequest = { selectedSnapshotState.value = null },
+        )
+    }
+
+    previewSnapshotState.value?.let { snapshot ->
+        SnapshotPeekDialog(
+            snapshot = snapshot,
+            onDismissRequest = { previewSnapshotState.value = null },
+        )
+    }
+}
+
+@Composable
+private fun SnapshotSidebar(
+    groups: List<SnapshotAppGroup>,
+    selectedAppId: String,
+    onSelectApp: (String) -> Unit,
+) {
+    // 左栏只承担“切换当前 App”职责，保持窄宽度和简单高亮，避免再次引入复杂分组滚动同步。
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxHeight()
+            .width(SnapshotSidebarWidth)
+            .background(MaterialTheme.colorScheme.surfaceContainerLowest),
+        contentPadding = PaddingValues(vertical = SnapshotSidebarPadding),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        lazyItems(groups, key = { it.appId }) { group ->
+            val selected = group.appId == selectedAppId
+            Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                shape = RoundedCornerShape(16.dp),
+                    .padding(horizontal = SnapshotSidebarPadding)
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(
+                        if (selected) {
+                            MaterialTheme.colorScheme.primaryContainer
+                        } else {
+                            Color.Transparent
+                        }
+                    )
+                    .noRippleClickable { onSelectApp(group.appId) }
+                    .padding(vertical = 10.dp),
+                contentAlignment = Alignment.Center,
             ) {
-                val modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                Text(
-                    text = "查看", modifier = Modifier
-                        .clickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn {
-                            selectedSnapshot = null
-                            mainVm.navigatePage(
-                                ImagePreviewRoute(
-                                    title = appInfoMapFlow.value[snapshotVal.appId]?.name
-                                        ?: snapshotVal.appId,
-                                    uri = snapshotVal.screenshotFile.absolutePath,
-                                )
-                            )
-                        }))
-                        .then(modifier)
-                )
-                HorizontalDivider()
-                Text(
-                    text = "分享到其他应用",
-                    modifier = Modifier
-                        .clickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn {
-                            selectedSnapshot = null
-                            val zipFile = SnapshotExt.snapshotZipFile(
-                                snapshotVal.id,
-                                snapshotVal.appId,
-                                snapshotVal.activityId
-                            )
-                            context.shareFile(zipFile, "分享快照文件")
-                        }))
-                        .then(modifier)
-                )
-                HorizontalDivider()
-                Text(
-                    text = "保存到下载",
-                    modifier = Modifier
-                        .clickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn(Dispatchers.IO) {
-                            selectedSnapshot = null
-                            toast("正在保存...")
-                            val zipFile = SnapshotExt.snapshotZipFile(
-                                snapshotVal.id,
-                                snapshotVal.appId,
-                                snapshotVal.activityId
-                            )
-                            context.saveFileToDownloads(zipFile)
-                        }))
-                        .then(modifier)
-                )
-                HorizontalDivider()
-                if (snapshotVal.githubAssetId != null) {
-                    Text(
-                        text = "复制链接", modifier = Modifier
-                            .clickable(onClick = throttle {
-                                selectedSnapshot = null
-                                copyText(IMPORT_SHORT_URL + snapshotVal.githubAssetId)
-                            })
-                            .then(modifier)
-                    )
-                } else {
-                    Text(
-                        text = "生成链接(需科学上网)", modifier = Modifier
-                            .clickable(onClick = throttle {
-                                selectedSnapshot = null
-                                mainVm.uploadOptions.startTask(
-                                    getFile = { SnapshotExt.snapshotZipFile(snapshotVal.id) },
-                                    showHref = { IMPORT_SHORT_URL + it.id },
-                                    onSuccessResult = {
-                                        DbSet.snapshotDao.update(snapshotVal.copy(githubAssetId = it.id))
-                                    }
-                                )
-                            })
-                            .then(modifier)
-                    )
-                }
-                HorizontalDivider()
-
-                Text(
-                    text = "保存截图到相册",
-                    modifier = Modifier
-                        .clickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn(Dispatchers.IO) {
-                            toast("正在保存...")
-                            selectedSnapshot = null
-                            requiredPermission(context, canWriteExternalStorage)
-                            ImageUtils.save2Album(BitmapFactory.decodeFile(snapshotVal.screenshotFile.absolutePath))
-                            toast("保存成功")
-                        }))
-                        .then(modifier)
-                )
-                HorizontalDivider()
-                Text(
-                    text = "替换截图(去除隐私)",
-                    modifier = Modifier
-                        .clickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn(Dispatchers.IO) {
-                            val uri = context.pickContentLauncher.launchForImageResult()
-                            val oldBitmap =
-                                BitmapFactory.decodeFile(snapshotVal.screenshotFile.absolutePath)
-                            val newBytes = UriUtils.uri2Bytes(uri)
-                            val newBitmap =
-                                BitmapFactory.decodeByteArray(newBytes, 0, newBytes.size)
-                            if (oldBitmap.width == newBitmap.width && oldBitmap.height == newBitmap.height) {
-                                snapshotVal.screenshotFile.writeBytes(newBytes)
-                                if (snapshotVal.githubAssetId != null) {
-                                    // 当本地快照变更时, 移除快照链接
-                                    DbSet.snapshotDao.deleteGithubAssetId(snapshotVal.id)
-                                }
-                                toast("替换成功")
-                                selectedSnapshot = null
-                            } else {
-                                toast("截图尺寸不一致, 无法替换")
-                            }
-                        }))
-                        .then(modifier)
-                )
-                HorizontalDivider()
-                Text(
-                    text = "删除", modifier = Modifier
-                        .clickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn {
-                            selectedSnapshot = null
-                            mainVm.dialogFlow.waitResult(
-                                title = "删除快照",
-                                text = "确定删除当前快照吗?",
-                                error = true,
-                            )
-                            DbSet.snapshotDao.delete(snapshotVal)
-                            withContext(Dispatchers.IO) {
-                                SnapshotExt.removeSnapshot(snapshotVal.id)
-                            }
-                            toast("删除成功")
-                        }))
-                        .then(modifier), color = colorScheme.error
+                AppIcon(
+                    appId = group.appId,
+                    modifier = Modifier.size(28.dp)
                 )
             }
         }
@@ -302,71 +247,319 @@ fun SnapshotPage() {
 }
 
 @Composable
-private fun SnapshotCard(
+private fun SnapshotGrid(
     modifier: Modifier = Modifier,
-    snapshot: Snapshot,
-    onClick: () -> Unit,
+    group: SnapshotAppGroup,
+    onClickSnapshot: (Snapshot) -> Unit,
+    onPreviewSnapshot: (Snapshot) -> Unit,
 ) {
-    Row(
-        modifier = modifier
-            .clickable(onClick = onClick)
-            .fillMaxWidth()
-            .height(IntrinsicSize.Min)
-            .padding(horizontal = itemHorizontalPadding, vertical = itemVerticalPadding / 2)
+    BoxWithConstraints(
+        modifier = modifier.fillMaxSize()
     ) {
-        Spacer(
-            modifier = Modifier
-                .fillMaxHeight()
-                .width(2.dp)
-                .background(MaterialTheme.colorScheme.primaryContainer),
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Column(
-            modifier = Modifier.weight(1f),
+        // 网格列数只允许 2~3 列，并以最小可读宽度做阈值，避免手机上为了“塞更多”把卡片压得太小。
+        val availableWidth = maxWidth - SnapshotGridPadding * 2
+        val canUseThreeColumns =
+            (availableWidth - SnapshotGridSpacing * 2) / 3 >= SnapshotGridMinCardWidth
+        val columnCount = if (canUseThreeColumns) 3 else 2
+        val cardWidth =
+            (availableWidth - SnapshotGridSpacing * (columnCount - 1)) / columnCount
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(columnCount),
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                start = SnapshotGridPadding,
+                top = SnapshotGridPadding,
+                end = SnapshotGridPadding,
+                bottom = SnapshotGridPadding * 2,
+            ),
+            horizontalArrangement = Arrangement.spacedBy(SnapshotGridSpacing),
+            verticalArrangement = Arrangement.spacedBy(SnapshotGridSpacing),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
+            gridItems(group.snapshots, key = { it.id }) { snapshot ->
+                SnapshotGridCard(
+                    snapshot = snapshot,
+                    thumbnailWidth = cardWidth,
+                    onClick = { onClickSnapshot(snapshot) },
+                    onPreview = { onPreviewSnapshot(snapshot) },
+                )
+            }
+            item(span = { GridItemSpan(columnCount) }) {
+                Spacer(modifier = Modifier.size(1.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SnapshotGridCard(
+    snapshot: Snapshot,
+    thumbnailWidth: Dp,
+    onClick: () -> Unit,
+    onPreview: () -> Unit,
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val colorScheme = MaterialTheme.colorScheme
+    val thumbnailWidthPx = remember(thumbnailWidth, density) {
+        with(density) { thumbnailWidth.roundToPx().coerceAtLeast(1) }
+    }
+    val thumbnailHeightPx = remember(thumbnailWidthPx) {
+        (thumbnailWidthPx * 4f / 3f).toInt().coerceAtLeast(1)
+    }
+
+    // 缩略图仍直接读本地 png，但显式限制目标尺寸，避免网格里把原始大图按全尺寸解码。
+    val thumbnailRequest = remember(snapshot.id, thumbnailWidthPx, thumbnailHeightPx) {
+        ImageRequest.Builder(context)
+            .data(snapshot.screenshotFile)
+            .size(thumbnailWidthPx, thumbnailHeightPx)
+            .diskCachePolicy(CachePolicy.DISABLED)
+            .build()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(20.dp))
+            .background(colorScheme.surfaceContainer)
+            .noRippleClickable(onClick = onClick)
+            .padding(10.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        // 点击和长按都放在缩略图区域处理，能兼容“点击更多”和“长按看大图”这两条不同路径。
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(3f / 4f)
+                .clip(RoundedCornerShape(16.dp))
+                .background(Color.Black.copy(alpha = 0.88f))
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = onPreview,
+                    onClickLabel = "打开快照操作菜单",
+                    onLongClickLabel = "预览快照大图",
+                )
+        ) {
+            AsyncImage(
+                model = thumbnailRequest,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit,
+                alignment = Alignment.Center,
+            )
+            Text(
+                text = snapshot.date,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(8.dp)
+                    .background(Color.Black.copy(alpha = 0.68f), CircleShape)
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = Color.White,
+                style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
+                maxLines = 1,
+            )
+        }
+        Text(
+            text = snapshot.shortActivityLabel(),
+            style = MaterialTheme.typography.bodySmall,
+            color = colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.MiddleEllipsis,
+        )
+    }
+}
+
+@Composable
+private fun SnapshotPeekDialog(
+    snapshot: Snapshot,
+    onDismissRequest: () -> Unit,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+
+    // 这个预览窗只承担“临时看细节”的职责，不复用正式图片预览页，避免再次引入缩放和分页复杂度。
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.72f))
+                .noRippleClickable(onClick = onDismissRequest),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.8f)
+                    .fillMaxHeight(0.8f)
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(colorScheme.surfaceContainerHighest)
+                    .noRippleClickable(onClick = {}),
             ) {
-                val appInfo = appInfoMapFlow.collectAsState().value[snapshot.appId]
-                val showAppName = appInfo?.name ?: snapshot.appId
-                Text(
-                    text = showAppName,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1,
-                    softWrap = false,
+                AsyncImage(
+                    model = snapshot.screenshotFile,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(12.dp),
+                    contentScale = ContentScale.Fit,
+                    alignment = Alignment.Center,
                 )
-                FixedTimeText(
-                    text = snapshot.date,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-            val showActivityId = if (snapshot.activityId != null) {
-                if (snapshot.activityId.startsWith(snapshot.appId)) {
-                    snapshot.activityId.substring(snapshot.appId.length)
-                } else {
-                    snapshot.activityId
-                }
-            } else {
-                null
-            }
-            if (showActivityId != null) {
-                Text(
-                    modifier = Modifier.height(MaterialTheme.typography.bodyMedium.lineHeight.value.dp),
-                    text = showActivityId,
-                    style = MaterialTheme.typography.bodyMedium,
-                    softWrap = false,
-                    maxLines = 1,
-                    overflow = TextOverflow.MiddleEllipsis,
-                )
-            } else {
-                Text(
-                    text = "null",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.typography.bodyMedium.color.copy(alpha = 0.5f)
+                PerfIconButton(
+                    imageVector = PerfIcon.Close,
+                    onClick = onDismissRequest,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp),
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun SnapshotActionDialog(
+    snapshot: Snapshot,
+    onDismissRequest: () -> Unit,
+) {
+    val context = LocalActivity.current as MainActivity
+    val mainVm = LocalMainViewModel.current
+    val vm = viewModel<SnapshotVm>()
+    val colorScheme = MaterialTheme.colorScheme
+
+    // 单条快照的管理入口保持原语义不变，只把触发源从旧列表项迁到了新网格卡片。
+    Dialog(onDismissRequest = onDismissRequest) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            val itemModifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+
+            Text(
+                text = "查看",
+                modifier = itemModifier.noRippleClickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn {
+                    onDismissRequest()
+                    mainVm.navigatePage(
+                        ImagePreviewRoute(
+                            title = appInfoMapFlow.value[snapshot.appId]?.name ?: snapshot.appId,
+                            uri = snapshot.screenshotFile.absolutePath,
+                        )
+                    )
+                }))
+            )
+            HorizontalDivider()
+            Text(
+                text = "分享到其他应用",
+                modifier = itemModifier.noRippleClickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn {
+                    onDismissRequest()
+                    val zipFile = SnapshotExt.snapshotZipFile(
+                        snapshot.id,
+                        snapshot.appId,
+                        snapshot.activityId,
+                    )
+                    context.shareFile(zipFile, "分享快照文件")
+                }))
+            )
+            HorizontalDivider()
+            Text(
+                text = "保存到下载",
+                modifier = itemModifier.noRippleClickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn(Dispatchers.IO) {
+                    onDismissRequest()
+                    toast("正在保存...")
+                    val zipFile = SnapshotExt.snapshotZipFile(
+                        snapshot.id,
+                        snapshot.appId,
+                        snapshot.activityId,
+                    )
+                    context.saveFileToDownloads(zipFile)
+                }))
+            )
+            HorizontalDivider()
+            if (snapshot.githubAssetId != null) {
+                Text(
+                    text = "复制链接",
+                    modifier = itemModifier.noRippleClickable(onClick = throttle {
+                        onDismissRequest()
+                        copyText(IMPORT_SHORT_URL + snapshot.githubAssetId)
+                    })
+                )
+            } else {
+                Text(
+                    text = "生成链接(需科学上网)",
+                    modifier = itemModifier.noRippleClickable(onClick = throttle {
+                        onDismissRequest()
+                        mainVm.uploadOptions.startTask(
+                            getFile = { SnapshotExt.snapshotZipFile(snapshot.id) },
+                            showHref = { IMPORT_SHORT_URL + it.id },
+                            onSuccessResult = {
+                                DbSet.snapshotDao.update(snapshot.copy(githubAssetId = it.id))
+                            }
+                        )
+                    })
+                )
+            }
+            HorizontalDivider()
+            Text(
+                text = "保存截图到相册",
+                modifier = itemModifier.noRippleClickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn(Dispatchers.IO) {
+                    toast("正在保存...")
+                    onDismissRequest()
+                    requiredPermission(context, canWriteExternalStorage)
+                    ImageUtils.save2Album(BitmapFactory.decodeFile(snapshot.screenshotFile.absolutePath))
+                    toast("保存成功")
+                }))
+            )
+            HorizontalDivider()
+            Text(
+                text = "替换截图(去除隐私)",
+                modifier = itemModifier.noRippleClickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn(Dispatchers.IO) {
+                    val uri = context.pickContentLauncher.launchForImageResult()
+                    val oldBitmap = BitmapFactory.decodeFile(snapshot.screenshotFile.absolutePath)
+                    val newBytes = UriUtils.uri2Bytes(uri)
+                    val newBitmap = BitmapFactory.decodeByteArray(newBytes, 0, newBytes.size)
+                    if (oldBitmap.width == newBitmap.width && oldBitmap.height == newBitmap.height) {
+                        snapshot.screenshotFile.writeBytes(newBytes)
+                        if (snapshot.githubAssetId != null) {
+                            DbSet.snapshotDao.deleteGithubAssetId(snapshot.id)
+                        }
+                        toast("替换成功")
+                        onDismissRequest()
+                    } else {
+                        toast("截图尺寸不一致, 无法替换")
+                    }
+                }))
+            )
+            HorizontalDivider()
+            Text(
+                text = "删除",
+                modifier = itemModifier.noRippleClickable(onClick = throttle(fn = vm.viewModelScope.launchAsFn {
+                    onDismissRequest()
+                    mainVm.dialogFlow.waitResult(
+                        title = "删除快照",
+                        text = "确定删除当前快照吗?",
+                        error = true,
+                    )
+                    DbSet.snapshotDao.delete(snapshot)
+                    withContext(Dispatchers.IO) {
+                        SnapshotExt.removeSnapshot(snapshot.id)
+                    }
+                    toast("删除成功")
+                })),
+                color = colorScheme.error,
+            )
+        }
+    }
+}
+
+private fun Snapshot.shortActivityLabel(): String {
+    val actualActivityId = activityId ?: return "未记录页面"
+    return if (actualActivityId.startsWith(appId)) {
+        actualActivityId.substring(appId.length).ifBlank { actualActivityId }
+    } else {
+        actualActivityId
     }
 }

--- a/app/src/main/kotlin/li/songe/gkd/ui/SnapshotPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/SnapshotPage.kt
@@ -19,11 +19,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.items as lazyItems
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
+import androidx.compose.foundation.lazy.staggeredgrid.items as staggeredItems
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
@@ -91,7 +91,7 @@ private val SnapshotSidebarWidth = 72.dp
 private val SnapshotSidebarPadding = 8.dp
 private val SnapshotGridSpacing = 12.dp
 private val SnapshotGridPadding = 16.dp
-private val SnapshotGridMinCardWidth = 136.dp
+private val SnapshotGridMinCardWidth = 172.dp // 增加最小宽度，确保横屏快照在格子里有足够高度
 
 @Composable
 fun SnapshotPage() {
@@ -105,7 +105,6 @@ fun SnapshotPage() {
     val previewSnapshotState = remember { mutableStateOf<Snapshot?>(null) }
     val selectedAppIdState = rememberSaveable { mutableStateOf<String?>(null) }
 
-    // 侧栏只有 App 维度，当前选中项若失效则自动回退到“最新快照所属 App”。
     val selectedGroup = remember(appGroups, selectedAppIdState.value) {
         appGroups.firstOrNull { it.appId == selectedAppIdState.value } ?: appGroups.firstOrNull()
     }
@@ -116,7 +115,6 @@ fun SnapshotPage() {
                 PerfIconButton(imageVector = PerfIcon.ArrowBack, onClick = { mainVm.popPage() })
             },
             title = {
-                // 顶栏保留页面名，同时补充当前 App 名称，避免侧栏只有图标时用户失去上下文。
                 Column {
                     Text(text = "快照记录")
                     selectedGroup?.let { group ->
@@ -211,7 +209,6 @@ private fun SnapshotSidebar(
     selectedAppId: String,
     onSelectApp: (String) -> Unit,
 ) {
-    // 左栏只承担“切换当前 App”职责，保持窄宽度和简单高亮，避免再次引入复杂分组滚动同步。
     LazyColumn(
         modifier = Modifier
             .fillMaxHeight()
@@ -256,16 +253,14 @@ private fun SnapshotGrid(
     BoxWithConstraints(
         modifier = modifier.fillMaxSize()
     ) {
-        // 网格列数只允许 2~3 列，并以最小可读宽度做阈值，避免手机上为了“塞更多”把卡片压得太小。
         val availableWidth = maxWidth - SnapshotGridPadding * 2
-        val canUseThreeColumns =
-            (availableWidth - SnapshotGridSpacing * 2) / 3 >= SnapshotGridMinCardWidth
-        val columnCount = if (canUseThreeColumns) 3 else 2
+        // 动态计算列数并限制最大列数，确保即便在横屏下，卡片宽度也足够显示横屏截图。
+        val columnCount = (availableWidth / SnapshotGridMinCardWidth).toInt().coerceIn(2, 5)
         val cardWidth =
             (availableWidth - SnapshotGridSpacing * (columnCount - 1)) / columnCount
 
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(columnCount),
+        LazyVerticalStaggeredGrid(
+            columns = StaggeredGridCells.Fixed(columnCount),
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(
                 start = SnapshotGridPadding,
@@ -274,9 +269,9 @@ private fun SnapshotGrid(
                 bottom = SnapshotGridPadding * 2,
             ),
             horizontalArrangement = Arrangement.spacedBy(SnapshotGridSpacing),
-            verticalArrangement = Arrangement.spacedBy(SnapshotGridSpacing),
+            verticalItemSpacing = SnapshotGridSpacing,
         ) {
-            gridItems(group.snapshots, key = { it.id }) { snapshot ->
+            staggeredItems(group.snapshots, key = { it.id }) { snapshot ->
                 SnapshotGridCard(
                     snapshot = snapshot,
                     thumbnailWidth = cardWidth,
@@ -284,7 +279,7 @@ private fun SnapshotGrid(
                     onPreview = { onPreviewSnapshot(snapshot) },
                 )
             }
-            item(span = { GridItemSpan(columnCount) }) {
+            item(span = StaggeredGridItemSpan.FullLine) {
                 Spacer(modifier = Modifier.size(1.dp))
             }
         }
@@ -304,11 +299,17 @@ private fun SnapshotGridCard(
     val thumbnailWidthPx = remember(thumbnailWidth, density) {
         with(density) { thumbnailWidth.roundToPx().coerceAtLeast(1) }
     }
-    val thumbnailHeightPx = remember(thumbnailWidthPx) {
-        (thumbnailWidthPx * 4f / 3f).toInt().coerceAtLeast(1)
+    val aspectRatio = remember(snapshot.screenWidth, snapshot.screenHeight) {
+        if (snapshot.screenWidth > 0 && snapshot.screenHeight > 0) {
+            snapshot.screenWidth.toFloat() / snapshot.screenHeight.toFloat()
+        } else {
+            3f / 4f
+        }
+    }
+    val thumbnailHeightPx = remember(thumbnailWidthPx, aspectRatio) {
+        (thumbnailWidthPx / aspectRatio).toInt().coerceAtLeast(1)
     }
 
-    // 缩略图仍直接读本地 png，但显式限制目标尺寸，避免网格里把原始大图按全尺寸解码。
     val thumbnailRequest = remember(snapshot.id, thumbnailWidthPx, thumbnailHeightPx) {
         ImageRequest.Builder(context)
             .data(snapshot.screenshotFile)
@@ -326,11 +327,10 @@ private fun SnapshotGridCard(
             .padding(10.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        // 点击和长按都放在缩略图区域处理，能兼容“点击更多”和“长按看大图”这两条不同路径。
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(3f / 4f)
+                .aspectRatio(aspectRatio)
                 .clip(RoundedCornerShape(16.dp))
                 .background(Color.Black.copy(alpha = 0.88f))
                 .combinedClickable(
@@ -375,23 +375,41 @@ private fun SnapshotPeekDialog(
     onDismissRequest: () -> Unit,
 ) {
     val colorScheme = MaterialTheme.colorScheme
+    val aspectRatio = remember(snapshot.screenWidth, snapshot.screenHeight) {
+        if (snapshot.screenWidth > 0 && snapshot.screenHeight > 0) {
+            snapshot.screenWidth.toFloat() / snapshot.screenHeight.toFloat()
+        } else {
+            1f
+        }
+    }
 
-    // 这个预览窗只承担“临时看细节”的职责，不复用正式图片预览页，避免再次引入缩放和分页复杂度。
     Dialog(
         onDismissRequest = onDismissRequest,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
-        Box(
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.Black.copy(alpha = 0.72f))
                 .noRippleClickable(onClick = onDismissRequest),
             contentAlignment = Alignment.Center,
         ) {
+            val parentWidth = maxWidth
+            val parentHeight = maxHeight
+            val parentAspectRatio = if (parentHeight > 0.dp) parentWidth / parentHeight else 1f
+
+            val containerModifier = if (aspectRatio > parentAspectRatio) {
+                Modifier
+                    .fillMaxWidth(0.85f)
+                    .aspectRatio(aspectRatio)
+            } else {
+                Modifier
+                    .fillMaxHeight(0.85f)
+                    .aspectRatio(aspectRatio)
+            }
+
             Box(
-                modifier = Modifier
-                    .fillMaxWidth(0.8f)
-                    .fillMaxHeight(0.8f)
+                modifier = containerModifier
                     .clip(RoundedCornerShape(24.dp))
                     .background(colorScheme.surfaceContainerHighest)
                     .noRippleClickable(onClick = {}),
@@ -427,7 +445,6 @@ private fun SnapshotActionDialog(
     val vm = viewModel<SnapshotVm>()
     val colorScheme = MaterialTheme.colorScheme
 
-    // 单条快照的管理入口保持原语义不变，只把触发源从旧列表项迁到了新网格卡片。
     Dialog(onDismissRequest = onDismissRequest) {
         Card(
             modifier = Modifier

--- a/app/src/main/kotlin/li/songe/gkd/ui/SnapshotVm.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/SnapshotVm.kt
@@ -1,9 +1,42 @@
 package li.songe.gkd.ui
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import li.songe.gkd.data.Snapshot
 import li.songe.gkd.db.DbSet
 import li.songe.gkd.ui.share.BaseViewModel
+import li.songe.gkd.util.appInfoMapFlow
+
+data class SnapshotAppGroup(
+    val appId: String,
+    val appName: String,
+    val latestSnapshotId: Long,
+    val snapshots: List<Snapshot>,
+)
 
 class SnapshotVm : BaseViewModel() {
     val snapshotsState = DbSet.snapshotDao.query().attachLoad()
+        .stateInit(emptyList())
+
+    // 双栏页只关心“某个 App 的快照集合”，先在 VM 内聚合可减少页面层的分支和重复排序。
+    val appGroupsState = combine(snapshotsState, appInfoMapFlow) { snapshots, appInfoMap ->
+        snapshots
+            .groupBy { it.appId }
+            .map { (appId, appSnapshots) ->
+                val sortedSnapshots = appSnapshots.sortedByDescending { it.id }
+                SnapshotAppGroup(
+                    appId = appId,
+                    appName = appInfoMap[appId]?.name ?: appId,
+                    latestSnapshotId = sortedSnapshots.first().id,
+                    snapshots = sortedSnapshots,
+                )
+            }
+            .sortedWith(
+                compareByDescending<SnapshotAppGroup> { it.latestSnapshotId }
+                    .thenBy { it.appName }
+            )
+    }
+        .flowOn(Dispatchers.Default)
         .stateInit(emptyList())
 }


### PR DESCRIPTION
### 预期用途为普通用户（分享快照为目的的群体）提供直观的快照选择
<details><summary>展开图片</summary>
<p>

![Screenshot_20260410_111045](https://github.com/user-attachments/assets/c6390e3a-8413-45b7-80d8-5d38187ee294)


</p>
</details> 

### 目前想发展逻辑是长按为多选快照，分享 删除。单击直接进入ImagePreviewPage，然后为它做一点额外的功能，右上角菜单按钮-弹出操作 Dialog菜单针对于此单快照，~~多快照选择没想好？？？逻辑会炸~~
