### PR TITLE
fix: not have api Err some rom

### DIFF
--- a/app/src/main/kotlin/li/songe/gkd/shizuku/ProxyUiAutomationConnection.kt
+++ b/app/src/main/kotlin/li/songe/gkd/shizuku/ProxyUiAutomationConnection.kt
@@ -244,23 +244,16 @@ class ProxyUiAutomationConnection : IUiAutomationConnection.Stub() {
         }
     }
 
+    // 部分魔改Android14 ROM可能无新api导致崩溃
     private fun restoreRotationStateLocked() {
         try {
             if (mInitialFrozenRotation != INITIAL_FROZEN_ROTATION_UNSPECIFIED) {
-                if (AndroidTarget.UPSIDE_DOWN_CAKE) {
-                    mWindowManager.freezeRotation(
-                        mInitialFrozenRotation,
-                        "UiAutomationConnection#restoreRotationStateLocked"
-                    )
-                } else {
-                    mWindowManager.freezeRotation(mInitialFrozenRotation)
-                }
+                mWindowManager.freezeRotationCompat(
+                    mInitialFrozenRotation,
+                    "UiAutomationConnection#restoreRotationStateLocked"
+                )
             } else {
-                if (AndroidTarget.UPSIDE_DOWN_CAKE) {
-                    mWindowManager.thawRotation("UiAutomationConnection#restoreRotationStateLocked")
-                } else {
-                    mWindowManager.thawRotation()
-                }
+                mWindowManager.thawRotationCompat("UiAutomationConnection#restoreRotationStateLocked")
             }
         } catch (_: RemoteException) {
         }

--- a/app/src/main/kotlin/li/songe/gkd/shizuku/WindowManager.kt
+++ b/app/src/main/kotlin/li/songe/gkd/shizuku/WindowManager.kt
@@ -2,11 +2,46 @@ package li.songe.gkd.shizuku
 
 import android.content.Context
 import android.view.IWindowManager
+import java.lang.reflect.InvocationTargetException
 
 class SafeWindowManager(val value: IWindowManager) {
     companion object {
         fun newBinder() = getShizukuService(Context.WINDOW_SERVICE)?.let {
             SafeWindowManager(IWindowManager.Stub.asInterface(it))
         }
+    }
+}
+
+// 反射查询实际api是否存在不依赖固定android版本判断
+fun IWindowManager.freezeRotationCompat(rotation: Int, caller: String) {
+    if (invokeCompat("freezeRotation", arrayOf(Int::class.javaPrimitiveType!!, String::class.java), rotation, caller)) {
+        return
+    }
+    invokeCompat("freezeRotation", arrayOf(Int::class.javaPrimitiveType!!), rotation)
+}
+
+fun IWindowManager.thawRotationCompat(caller: String) {
+    if (invokeCompat("thawRotation", arrayOf(String::class.java), caller)) {
+        return
+    }
+    invokeCompat("thawRotation", emptyArray())
+}
+
+private fun IWindowManager.invokeCompat(
+    name: String,
+    parameterTypes: Array<Class<*>>,
+    vararg args: Any?,
+): Boolean {
+    return try {
+        javaClass.getMethod(name, *parameterTypes).invoke(this, *args)
+        true
+    } catch (_: NoSuchMethodException) {
+        false
+    } catch (_: NoSuchMethodError) {
+        false
+    } catch (_: AbstractMethodError) {
+        false
+    } catch (e: InvocationTargetException) {
+        throw e.targetException
     }
 }


### PR DESCRIPTION
### 部分国产rom Android14没有新hidden api(亦可能魔改)不存在此api导致崩溃

### 修复方法
原Android版本判断改为反射查询系统是否真的存在再调用api


<details><summary>log片段</summary>
<p>

```
13:15:29.412 updateTopActivity, binder:18938_1, shizuku.FixedTaskStackListener.onTaskStackChanged(TaskStackListener.kt:27)
com.tencent.mm/.plugin.appbrand.ui.AppBrandPluginUI/0 -> com.tencent.mm/.plugin.voip.ui.VideoActivity/0 (scene=TaskStack)

13:15:29.420 LifecycleCallbacks, main, service.A11yService.<init>(A11yService.kt:103)
onA11yConnected -> SelectToSpeakService

13:15:29.669 Toast, main, service.A11yService.<init>(A11yService.kt:136)
无障碍已启动

13:15:29.717 A11yFeat, DefaultDispatcher-worker-5, a11y.initRuleChangedLog(A11yFeat.kt:144)
[0]: TopActivity(appId=com.tencent.mm, activityId=com.tencent.mm.plugin.voip.ui.VideoActivity, number=0)
[1]: id:667, v:455, type:app, gKey=19, gName:功能类-订阅号-展开更早的消息, index:1, key:1, status:ok

13:15:30.755 Toast, main, App.onCreate(App.kt:213)
No interface method freezeRotation(ILjava/lang/String;)V in class Landroid/view/IWindowManager; or its super classes (declaration of 'android.view.IWindowManager' appears in /system/framework/framework.jar!classes4.dex)

13:15:30.756 App, main, App.onCreate(App.kt:214)
[0]: UncaughtExceptionHandler
[1]: Thread[main,5,main]
[2]: java.lang.NoSuchMethodError: No interface method freezeRotation(ILjava/lang/String;)V in class Landroid/view/IWindowManager; or its super classes (declaration of 'android.view.IWindowManager' appears in /system/framework/framework.jar!classes4.dex)
	at n34.disconnect(r8-map-id-bc0c3a82c6d94955b5fa6a93dfeadf1085d7969e524c24f71d40801ad3442c5d:50)
	at android.app.UiAutomation.disconnect(UiAutomation.java:449)
	at yw.d(r8-map-id-bc0c3a82c6d94955b5fa6a93dfeadf1085d7969e524c24f71d40801ad3442c5d:31)
	at yw.f(r8-map-id-bc0c3a82c6d94955b5fa6a93dfeadf1085d7969e524c24f71d40801ad3442c5d:6)
	at h1.run(r8-map-id-bc0c3a82c6d94955b5fa6a93dfeadf1085d7969e524c24f71d40801ad3442c5d:38)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:224)
	at android.os.Looper.loop(Looper.java:318)
	at android.app.ActivityThread.main(ActivityThread.java:8777)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:561)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1013)


13:15:34.915 App, main, App.onCreate(App.kt:211)

13:15:34.982 LifecycleCallbacks, main, service.A11yService.<init>(A11yService.kt:103)
onCreated -> SelectToSpeakService

13:15:34.983 Toast, main, service.A11yService.<init>(A11yService.kt:111)
当前为自动化模式，无障碍将自动关闭
```

</p>
</details> 

<details><summary>崩溃截图</summary>
<p>

<img width="591" height="1280" alt="图片" src="https://github.com/user-attachments/assets/360d948b-8b77-4547-91e6-d74047678961" />

</p>
</details> 

[log-1776837345931.zip](https://github.com/user-attachments/files/26988184/log-1776837345931.zip)

