### PR TITLE
feat: SnapShot Toast in Multiple Situation

### DIFF
--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -131,21 +131,40 @@ object SnapshotExt {
     }
     // App拒绝提供画面判定逻辑
     private fun isAppProtected(bitmap: Bitmap): Boolean {
+        fun Bitmap.recycleIfTemp() { if (this !== bitmap) recycle() }
+        // 去掉状态栏
+        val tempBp = if (BarUtils.checkStatusBarVisible() == true) {
+            cropBitmapStatusBar(bitmap)
+        } else {
+            bitmap
+        }
         // 缩小图片
         val size = 64
-        val scaled = bitmap.scale(size, size, false)
+        val scaled = tempBp.scale(size, size, false)
+        tempBp.recycleIfTemp()
+
+        /* 强制转为 ARGB_8888（软件位图）
+        部分设备,Android版本scale()返回仍是HARDWARE
+        bitmap在 gpu内存,cpu无法直接读,会崩溃
+         */
+        val softBitmap = if (scaled.config == Bitmap.Config.HARDWARE) {
+            val copy = scaled.copy(Bitmap.Config.ARGB_8888, false)
+            scaled.recycleIfTemp()
+            copy ?: return false  // copy 失败（极端 OOM）直接返回，不继续执行
+        } else {
+            scaled
+        }
         //  像素一次性读取到数组
         val pixels = IntArray(size * size)
-        scaled.getPixels(pixels, 0, size, 0, 0, size, size)
-        // 内存回收
-        if (scaled !== bitmap) {
-            scaled.recycle()
-        }
-        val ignore = (size * 0.2).toInt()  //  忽略图片编译
+        softBitmap.getPixels(pixels, 0, size, 0, 0, size, size)
+        softBitmap.recycleIfTemp()
+        val ignore = (size * 0.1).toInt()  //  忽略图片边缘
         // 统计变量
         var sum = 0.0  //  亮度总和
         var sumSq = 0.0  //  平方总和
         var count = 0 // 样本数量
+        //  统计极值像素占比
+        var nearBlackCount = 0
         // 采样
         val step = 2 //隔一个像素取样
         for (y in ignore until size - ignore step step) {  // ignore(忽略边缘)
@@ -161,6 +180,7 @@ object SnapshotExt {
                 sum += l
                 sumSq += l * l
                 count++
+                if (l < 10) nearBlackCount++
             }
         }
         // 防止除零
@@ -169,8 +189,13 @@ object SnapshotExt {
         val mean = sum / count
         val variance = sumSq / count - mean * mean
 
+        // 极值(纯黑)像素占比
+        val blackRatio = nearBlackCount.toDouble() / count
+        // 判断条件拆分,低方差+像素高度集中在极端值
+        val isNearlyUniform = variance < 15.0  // 放宽，包容轻微噪点
+        val isDominantlyBlack = blackRatio > 0.85 && mean < 15.0
         // 判断值设定
-        return variance < 2 && (mean !in 20.0..235.0)
+        return isNearlyUniform && (isDominantlyBlack)
     }
     private val captureLoading = MutableStateFlow(false)
     suspend fun captureSnapshot(forcedCropStatusBar: Boolean = false): ComplexSnapshot {

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -139,7 +139,7 @@ object SnapshotExt {
             if (storeFlow.value.showSaveSnapshotToast) {
                 toast("正在保存快照...", forced = true)
             }
-            var notHaveScreen = true
+            var notHaveScreen = false
             val (snapshot, bitmap) = coroutineScope {
                 val d1 = async(Dispatchers.IO) {
                     val appId = rootNode.packageName.toString()
@@ -171,10 +171,7 @@ object SnapshotExt {
                 val d2 = async(Dispatchers.IO) {
                     (A11yRuleEngine.screenshot()
                         ?: ScreenshotService.screenshot()
-                        ?: run {
-                            notHaveScreen = false
-                            emptyScreenBitmap("无截图权限\n请自行替换")
-                        }
+                        ?: (emptyScreenBitmap("无截图权限\n请自行替换") .also { notHaveScreen = true }
                             ).let {
                             if (storeFlow.value.hideSnapshotStatusBar && (forcedCropStatusBar || BarUtils.checkStatusBarVisible() == true)) {
                                 cropBitmapStatusBar(it)
@@ -182,6 +179,7 @@ object SnapshotExt {
                                 it
                             }
                         }
+                    )
                 }
                 d1.await() to d2.await()
             }
@@ -201,9 +199,9 @@ object SnapshotExt {
                 DbSet.snapshotDao.insert(snapshot.toSnapshot())
             }
             val tip = if (notHaveScreen) {
-                "快照成功"
-            } else {
                 "快照成功 (无截图)"
+            } else {
+                "快照成功"
             }
             toast(tip, forced = true)
             val desc = snapshot.appInfo?.name ?: snapshot.appId

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -132,16 +132,10 @@ object SnapshotExt {
     // App拒绝提供画面判定逻辑
     private fun isAppProtected(bitmap: Bitmap): Boolean {
         fun Bitmap.recycleIfTemp() { if (this !== bitmap) recycle() }
-        // 去掉状态栏
-        val tempBp = if (BarUtils.checkStatusBarVisible() == true) {
-            cropBitmapStatusBar(bitmap)
-        } else {
-            bitmap
-        }
         // 缩小图片
         val size = 64
-        val scaled = tempBp.scale(size, size, false)
-        tempBp.recycleIfTemp()
+        val scaled = bitmap.scale(size, size, false)
+        bitmap.recycleIfTemp()
 
         /* 强制转为 ARGB_8888（软件位图）
         部分设备,Android版本scale()返回仍是HARDWARE
@@ -158,7 +152,7 @@ object SnapshotExt {
         val pixels = IntArray(size * size)
         softBitmap.getPixels(pixels, 0, size, 0, 0, size, size)
         softBitmap.recycleIfTemp()
-        val ignore = (size * 0.1).toInt()  //  忽略图片边缘
+        val ignore = (size * 0.08).toInt()  //  忽略图片边缘
         // 统计变量
         var sum = 0.0  //  亮度总和
         var sumSq = 0.0  //  平方总和

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -135,7 +135,6 @@ object SnapshotExt {
         // 缩小图片
         val size = 64
         val scaled = bitmap.scale(size, size, false)
-        bitmap.recycleIfTemp()
 
         /* 强制转为 ARGB_8888（软件位图）
         部分设备,Android版本scale()返回仍是HARDWARE

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -2,6 +2,7 @@ package li.songe.gkd.util
 
 import android.graphics.Bitmap
 import androidx.core.graphics.createBitmap
+import androidx.core.graphics.scale
 import androidx.core.graphics.set
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -128,6 +129,49 @@ object SnapshotExt {
         NotHave,
         Block,
     }
+    // App拒绝提供画面判定逻辑
+    private fun isAppProtected(bitmap: Bitmap): Boolean {
+        // 缩小图片
+        val size = 64
+        val scaled = bitmap.scale(size, size, false)
+        //  像素一次性读取到数组
+        val pixels = IntArray(size * size)
+        scaled.getPixels(pixels, 0, size, 0, 0, size, size)
+        // 内存回收
+        if (scaled !== bitmap) {
+            scaled.recycle()
+        }
+        val ignore = (size * 0.2).toInt()  //  忽略图片编译
+        // 统计变量
+        var sum = 0.0  //  亮度总和
+        var sumSq = 0.0  //  平方总和
+        var count = 0 // 样本数量
+        // 采样
+        val step = 2 //隔一个像素取样
+        for (y in ignore until size - ignore step step) {  // ignore(忽略边缘)
+            for (x in ignore until size - ignore step step) {
+                // 提取RGB
+                val p = pixels[y * size + x]
+                val r = (p shr 16) and 0xff
+                val g = (p shr 8) and 0xff
+                val b = p and 0xff
+                // 计算亮度
+                val l = 0.299 * r + 0.587 * g + 0.114 * b
+                // 统计
+                sum += l
+                sumSq += l * l
+                count++
+            }
+        }
+        // 防止除零
+        if (count == 0) return false
+        // 平均值和方差计算
+        val mean = sum / count
+        val variance = sumSq / count - mean * mean
+
+        // 判断值设定
+        return variance < 2 && (mean !in 20.0..235.0)
+    }
     private val captureLoading = MutableStateFlow(false)
     suspend fun captureSnapshot(forcedCropStatusBar: Boolean = false): ComplexSnapshot {
         if (A11yRuleEngine.instance == null) {
@@ -181,9 +225,9 @@ object SnapshotExt {
                         rawPicture == null -> {
                             emptyScreenBitmap("无截图权限\n请自行替换") to ScreenWhy.NotHave
                         }
-                        /*isAppProtected(rawPicture) -> {
+                        isAppProtected(rawPicture) -> {
                             rawPicture to ScreenWhy.Block
-                        }*/
+                        }
                         else -> {
                             rawPicture to ScreenWhy.Pass
                         }

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -139,6 +139,7 @@ object SnapshotExt {
             if (storeFlow.value.showSaveSnapshotToast) {
                 toast("正在保存快照...", forced = true)
             }
+            var notHaveScreen = true
             val (snapshot, bitmap) = coroutineScope {
                 val d1 = async(Dispatchers.IO) {
                     val appId = rootNode.packageName.toString()
@@ -170,7 +171,10 @@ object SnapshotExt {
                 val d2 = async(Dispatchers.IO) {
                     (A11yRuleEngine.screenshot()
                         ?: ScreenshotService.screenshot()
-                        ?: emptyScreenBitmap("无截图权限\n请自行替换")
+                        ?: run {
+                            notHaveScreen = false
+                            emptyScreenBitmap("无截图权限\n请自行替换")
+                        }
                             ).let {
                             if (storeFlow.value.hideSnapshotStatusBar && (forcedCropStatusBar || BarUtils.checkStatusBarVisible() == true)) {
                                 cropBitmapStatusBar(it)
@@ -196,7 +200,12 @@ object SnapshotExt {
                 )
                 DbSet.snapshotDao.insert(snapshot.toSnapshot())
             }
-            toast("快照成功", forced = true)
+            val tip = if (notHaveScreen) {
+                "快照成功"
+            } else {
+                "快照成功 (无截图)"
+            }
+            toast(tip, forced = true)
             val desc = snapshot.appInfo?.name ?: snapshot.appId
             snapshotNotif.copy(text = "快照「$desc」已保存至记录").notifySelf()
             return snapshot

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -280,7 +280,7 @@ object SnapshotExt {
             }
             val tip = when (currentStatus) {
                 ScreenWhy.NotHave -> "快照成功 (无截图)"
-                ScreenWhy.Block -> "快照成功 (此App禁止截屏??)"
+                ScreenWhy.Block -> "快照成功 (应用可能禁止截图)"
                 ScreenWhy.Pass -> "快照成功"
             }
             toast(tip, forced = true)

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -280,7 +280,7 @@ object SnapshotExt {
             }
             val tip = when (currentStatus) {
                 ScreenWhy.NotHave -> "快照成功 (无截图)"
-                ScreenWhy.Block -> "快照成功 (目标App疑似截屏保护)"
+                ScreenWhy.Block -> "快照成功 (此App禁止截屏??)"
                 ScreenWhy.Pass -> "快照成功"
             }
             toast(tip, forced = true)

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -122,7 +122,12 @@ object SnapshotExt {
         }
         return tempBp
     }
-
+    // 截图三种状态
+    private enum class ScreenWhy {
+        Pass,
+        NotHave,
+        Block,
+    }
     private val captureLoading = MutableStateFlow(false)
     suspend fun captureSnapshot(forcedCropStatusBar: Boolean = false): ComplexSnapshot {
         if (A11yRuleEngine.instance == null) {
@@ -139,8 +144,7 @@ object SnapshotExt {
             if (storeFlow.value.showSaveSnapshotToast) {
                 toast("正在保存快照...", forced = true)
             }
-            var notHaveScreen = false
-            val (snapshot, bitmap) = coroutineScope {
+            val (snapshot, screenResult) = coroutineScope {  // 快照数据+截图(图片 && 状态)
                 val d1 = async(Dispatchers.IO) {
                     val appId = rootNode.packageName.toString()
                     var activityId = shizukuContextFlow.value.topCpn()?.className
@@ -169,20 +173,34 @@ object SnapshotExt {
                     )
                 }
                 val d2 = async(Dispatchers.IO) {
-                    (A11yRuleEngine.screenshot()
-                        ?: ScreenshotService.screenshot()
-                        ?: (emptyScreenBitmap("无截图权限\n请自行替换") .also { notHaveScreen = true }
-                            ).let {
-                            if (storeFlow.value.hideSnapshotStatusBar && (forcedCropStatusBar || BarUtils.checkStatusBarVisible() == true)) {
-                                cropBitmapStatusBar(it)
-                            } else {
-                                it
-                            }
+                    val rawPicture =  // 获取原始图片
+                        A11yRuleEngine.screenshot()  // 无障碍
+                        ?: ScreenshotService.screenshot() // 截图服务
+
+                    val (finalBitmap, status) = when {
+                        rawPicture == null -> {
+                            emptyScreenBitmap("无截图权限\n请自行替换") to ScreenWhy.NotHave
                         }
-                    )
+                        /*isAppProtected(rawPicture) -> {
+                            rawPicture to ScreenWhy.Block
+                        }*/
+                        else -> {
+                            rawPicture to ScreenWhy.Pass
+                        }
+                    }
+
+                    val processedBitmap = if (status == ScreenWhy.Pass &&
+                        storeFlow.value.hideSnapshotStatusBar && (forcedCropStatusBar || BarUtils.checkStatusBarVisible() == true)) {
+                          cropBitmapStatusBar(finalBitmap)
+                    } else {
+                        finalBitmap
+                    }
+                    processedBitmap to status
                 }
                 d1.await() to d2.await()
             }
+
+            val (bitmap, currentStatus) = screenResult // 拆开(图片+状态)
             withContext(Dispatchers.IO) {
                 snapshotParentPath(snapshot.id).autoMk()
                 screenshotFile(snapshot.id).outputStream().use { stream ->
@@ -198,10 +216,10 @@ object SnapshotExt {
                 )
                 DbSet.snapshotDao.insert(snapshot.toSnapshot())
             }
-            val tip = if (notHaveScreen) {
-                "快照成功 (无截图)"
-            } else {
-                "快照成功"
+            val tip = when (currentStatus) {
+                ScreenWhy.NotHave -> "快照成功 (无截图)"
+                ScreenWhy.Block -> "快照成功 (目标App疑似截屏保护)"
+                ScreenWhy.Pass -> "快照成功"
             }
             toast(tip, forced = true)
             val desc = snapshot.appInfo?.name ?: snapshot.appId


### PR DESCRIPTION
### 这里有三种情况提示  
1. 正常截图
2. 截图权限受限
3. 目标app安全策略截图后黑屏(仅限声明app自身)  
用枚举类囊括

其中`App拒绝提供画面判定逻辑`用的方差,亮度均值,纯黑像素占比来综合判断是否符合条件

测试基本能做到准确识别,除非极端的*纯黑+少量元素*误识别至`Block`,如(快照预览图加载页,截取快照无截图权限页)
但是绝大部分app未见到这种设计情况,实际使用误识别几乎为0

### 后续,补充下模拟测试

<img width="1639" height="721" alt="PixPin_2026-05-16_20-03-08" src="https://github.com/user-attachments/assets/94876675-98b2-4a31-b6f9-90a62bceab29" />
