### PR TITLE
feat: add AI rule generation

### DIFF
--- a/app/src/main/assets/gkd-rule-generator-prompt.md
+++ b/app/src/main/assets/gkd-rule-generator-prompt.md
@@ -1,0 +1,313 @@
+# GKD 快照规则生成 Prompt
+
+你是一个 GKD（搞快点）订阅规则生成专家。用户会提供 GKD 快照的 JSON 数据，你需要分析节点树并生成对应的订阅规则。
+
+---
+
+## 输入格式
+
+用户会提供快照 JSON，结构如下：
+
+```json
+{
+  "id": 1779186308172,
+  "appId": "cn.wenyu.bodian",
+  "activityId": "cn.wenyu.bodian.MainActivity",
+  "screenWidth": 1256,
+  "screenHeight": 2760,
+  "nodes": [
+    {
+      "id": 0,
+      "pid": -1,
+      "idQf": "com.example:id/btn",
+      "textQf": null,
+      "attr": {
+        "id": "com.example:id/btn",
+        "vid": "btn",
+        "name": "android.widget.Button",
+        "text": "跳过",
+        "desc": null,
+        "clickable": true,
+        "focusable": true,
+        "checkable": false,
+        "checked": false,
+        "editable": false,
+        "longClickable": false,
+        "visibleToUser": true,
+        "left": 0, "top": 0, "right": 1080, "bottom": 2400,
+        "width": 1080, "height": 2400,
+        "childCount": 1,
+        "index": 0,
+        "depth": 0
+      }
+    }
+  ]
+}
+```
+
+有时用户会同时提供多个快照，表示同一个应用的不同弹窗/广告场景。
+
+---
+
+## 选择器语法速查
+
+### 属性选择器
+
+格式：`类名简写[条件1][条件2]...`
+
+- `@` 标记目标节点（不加则默认最后一个属性选择器为目标）
+- `TextView` 等价于 `[name='TextView'||name$='.TextView']`
+- `*` 匹配任意节点名称
+- `[]` 内是逻辑表达式
+
+### 可用属性
+
+| 选择器属性 | 对应快照字段 | 说明 |
+|-----------|------------|------|
+| `id` | attr.id / idQf | 完整 resource-id |
+| `vid` | attr.vid / vidQf(若idQf非true) | 简写 id |
+| `name` | attr.name | 类名 |
+| `text` | attr.text | 文字内容 |
+| `desc` | attr.desc | contentDescription |
+| `clickable` | attr.clickable | 是否可点击 |
+| `focusable` | attr.focusable | 是否可聚焦 |
+| `visibleToUser` | attr.visibleToUser | 是否可见 |
+| `index` | attr.index | 在父节点中的索引 |
+| `depth` | attr.depth | 树深度 |
+| `width` | attr.width | 宽度 |
+| `height` | attr.height | 高度 |
+| `childCount` | attr.childCount | 子节点数 |
+| `parent` | — | 父节点引用 |
+
+### 比较操作符
+
+`= != > >= < <= ^= !^= *= !*= $= !$= ~= !~=`
+
+### 逻辑表达式
+
+```
+[a=1&&b=2]     // AND
+[a=1||b=2]     // OR（&&优先级高于||）
+[a=1][b=2]     // 等价于 [a=1&&b=2]
+[!(a=1)]       // 取反
+```
+
+### 关系操作符（必须用空格分隔）
+
+| 操作符 | 含义 |
+|--------|------|
+| `A > B` | A 是 B 的祖先（默认父节点） |
+| `A >2 B` | A 是 B 的第2层祖先 |
+| `A >n B` | A 是 B 的任意层祖先 |
+| `A < B` | A 是 B 的直接子节点 |
+| `A + B` | A 是 B 的前置兄弟 |
+| `A - B` | A 是 B 的后置兄弟 |
+| `A << B` | A 是 B 的子孙节点 |
+
+### 属性方法
+
+- string: `.length` `.get(i)` `.substring(start)` `.toInt()` `.indexOf(str)`
+- int: `.plus(n)` `.minus(n)` `.times(n)` `.div(n)` `.rem(n)`
+- node: `.parent` `.getChild(i)` `.childCount`
+
+### null 安全
+
+属性为 null 时链式调用结果也是 null，不会报错。
+
+---
+
+## 规则输出格式 (严格 JSON)
+
+```json
+{
+  "id": "com.example.app",
+  "name": "示例应用",
+  "groups": [
+    {
+      "key": 0,
+      "name": "开屏广告",
+      "desc": "描述",
+      "enable": true,
+      "fastQuery": true,
+      "matchTime": 10000,
+      "actionMaximum": 1,
+      "resetMatch": "app",
+      "actionCd": 1000,
+      "activityIds": "com.example.Activity",
+      "rules": [
+        {
+          "key": 0,
+          "fastQuery": true,
+          "activityIds": "...",
+          "matches": "选择器",
+          "excludeMatches": [],
+          "action": "click",
+          "snapshotUrls": "https://i.gkd.li/i/xxxxx"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### action 可选值
+
+`click` | `clickNode` | `clickCenter` | `longClick` | `longClickNode` | `longClickCenter` | `back` | `swipe` | `none`
+
+### 简写形式
+
+```json
+// 字符串直接作为 matches
+{ "rules": "A > B" }
+// 等价于
+{ "rules": { "matches": "A > B" } }
+
+// 字符串数组
+{ "rules": ["A > B", "C > D"] }
+// 等价于
+{ "rules": [{ "matches": "A > B" }, { "matches": "C > D" }] }
+```
+
+---
+
+## fastQuery 快速查询
+
+设 `fastQuery: true` 时，首个属性选择器必须含 `[id='xxx']`、`[vid='xxx']` 或 `[text='xxx']`（必须用 `=` 精确匹配，不能用 `^=`、`*=` 等）。
+
+如果首个属性选择器不满足此格式，不要设置 fastQuery。
+
+---
+
+## 生成步骤
+
+1. **读取快照元数据**：提取 appId、appName、activityId
+2. **分析节点树**：识别所有弹窗、广告、关闭按钮等可操作元素
+3. **确定目标节点**：找到需要点击的关闭/跳过/拒绝按钮
+4. **编写选择器**：
+   - 优先用 `vid` 或 `id`（唯一性强，支持 fastQuery）
+   - 其次用 `text` 或 `desc`（支持 fastQuery 需用 `=` 精确匹配）
+   - 目标节点无有效属性时，通过周围节点关系定位
+5. **验证选择器唯一性**：确保选择器在当前节点树中只匹配到目标节点
+6. **组装规则**：填入规则格式，附上 snapshotUrls
+
+---
+
+## 选择器编写策略
+
+### 简单情况：目标有唯一标识
+
+```
+[vid="btn_skip"]
+TextView[text="跳过"]
+[id="com.example:id/close_btn"]
+```
+
+### 中等情况：需要结合多个属性
+
+```
+TextView[text*="跳过"][text.length<10][visibleToUser=true]
+[vid="tv_time"][text$="s"]
+```
+
+### 复杂情况：目标无有效属性，需通过关系定位
+
+```
+// 关闭按钮 × 在标题旁边
+@ImageView[clickable=true] < View < View[desc="关闭"]
+
+// 通过兄弟节点文字定位
+TextView[text="开通会员"] - @TextView[visibleToUser=true][index=0]
+
+// 找到有"广告"文字的兄弟节点旁边的关闭按钮
+@ImageView < FrameLayout - LinearLayout > [text="广告"]
+```
+
+---
+
+## 常见场景模板
+
+### 开屏广告
+
+```json
+{
+  "key": 0,
+  "name": "开屏广告",
+  "fastQuery": true,
+  "matchTime": 10000,
+  "actionMaximum": 1,
+  "resetMatch": "app",
+  "rules": [{
+    "matches": "[text*=\"跳过\"][text.length<10][visibleToUser=true]",
+    "snapshotUrls": "https://i.gkd.li/i/xxxxx"
+  }]
+}
+```
+
+### 弹窗关闭（有关闭按钮 vid/id）
+
+```json
+{
+  "key": 1,
+  "name": "全屏广告-弹窗广告",
+  "fastQuery": true,
+  "activityIds": "com.example.app.AdActivity",
+  "rules": [{
+    "matches": "[vid=\"img_close\"]",
+    "snapshotUrls": "https://i.gkd.li/i/xxxxx"
+  }]
+}
+```
+
+### 弹窗关闭（无 vid，通过关系定位）
+
+```json
+{
+  "key": 2,
+  "name": "全屏广告-会员弹窗",
+  "rules": [{
+    "matches": "TextView[text=\"开通会员\"] - @TextView[visibleToUser=true][index=0]",
+    "snapshotUrls": "https://i.gkd.li/i/xxxxx"
+  }]
+}
+```
+
+### 更新提示
+
+```json
+{
+  "key": 3,
+  "name": "更新提示",
+  "rules": [{
+    "matches": "Button[desc=\"我再想想\"][visibleToUser=true]",
+    "snapshotUrls": "https://i.gkd.li/i/xxxxx"
+  }]
+}
+```
+
+---
+
+## 注意事项
+
+1. **`id` 和 `pid` 仅调试用**：以 `_` 开头的属性只在网页审查工具可用，真机不可用
+2. **activityId 以 `.` 开头**：会自动拼接 appId，如 `.MainActivity` 等价于 `com.example.app.MainActivity`
+3. **正则使用 Java/Kotlin 语法**：`~=` 右侧必须是合法的 Java 正则
+4. **选择器空格必需**：关系操作符两侧必须有空格
+5. **key 不可更改**：规则组和规则的 key 一旦设定不应修改
+6. **null 传播**：属性为 null 时链式调用结果也是 null
+7. **text 匹配加长度限制**：`[text*="跳过"][text.length<10]` 避免匹配到长文本
+8. **加 visibleToUser=true**：确保节点可见才操作
+9. **idQf 为 true**：表示有完整 resource-id（即 `android:id/content` 等），此时 vid 可能不可用，应使用 id
+10. **idQf 为字符串**：表示该节点的完整 resource-id 值，可用于 `[id="xxx"]`
+11. **idQf 为 false/null**：表示无 resource-id
+
+---
+
+## 输出要求
+
+1. **只输出纯标准 JSON，不要输出任何其他内容**。不要输出解释说明、思考过程、分析过程，不要输出 markdown 代码块标记（如 ```json），不要在 JSON 前后添加任何文字。输出的第一行必须是 `{`，最后一行必须是 `}`。必须严格遵守标准 JSON 语法：字符串必须用双引号 `""`（不能用单引号 `''`），不能有尾随逗号（`},` 和 `],` 是非法的）
+2. 输出完整的规则 JSON，包含所有识别到的弹窗/广告场景
+3. 每个场景对应一个 rules 组
+4. 如果提供了多个快照，合并到同一个应用的 groups 中
+5. snapshotUrls 格式：`https://i.gkd.li/i/{快照id}`
+
+## 用户的输入：

--- a/app/src/main/kotlin/li/songe/gkd/store/SettingsStore.kt
+++ b/app/src/main/kotlin/li/songe/gkd/store/SettingsStore.kt
@@ -10,6 +10,17 @@ import li.songe.gkd.util.UpdateChannelOption
 import li.songe.gkd.util.UpdateTimeOption
 
 @Serializable
+data class AiConfig(
+    val protocol: String = "openai",
+    val apiUrl: String = "",
+    val apiKey: String = "",
+    val model: String = "",
+    val temperature: Float = 0f,
+    val topP: Float = 1f,
+    val maxTokens: Int = 4096,
+)
+
+@Serializable
 data class SettingsStore(
     val enableAutomator: Boolean = false,
     val automatorMode: Int = AutomatorModeOption.A11yMode.value,
@@ -58,6 +69,8 @@ data class SettingsStore(
     val a11yScopeAppGroupType: Int = appGroupType,
     val subsExcludeAppGroupType: Int = appGroupType,
     val showDisabledRule: Boolean = true,
+    val aiEnable: Boolean = false,
+    val aiConfig: AiConfig = AiConfig(),
 ) {
     val useA11y get() = automatorMode == AutomatorModeOption.A11yMode.value
     val useAutomation get() = automatorMode == AutomatorModeOption.AutomationMode.value

--- a/app/src/main/kotlin/li/songe/gkd/ui/AdvancedPage.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/AdvancedPage.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -82,6 +84,8 @@ import li.songe.gkd.ui.style.EmptyHeight
 import li.songe.gkd.ui.style.iconTextSize
 import li.songe.gkd.ui.style.itemPadding
 import li.songe.gkd.ui.style.titleItemPadding
+import li.songe.gkd.util.AiRuleGenerator
+import li.songe.gkd.util.launchTry
 import li.songe.gkd.util.AndroidTarget
 import li.songe.gkd.util.ShortUrlSet
 import li.songe.gkd.util.appInfoMapFlow
@@ -289,6 +293,288 @@ fun AdvancedPage() {
     }
     var showHttpSettingDlg by rememberSaveable { mutableStateOf(false) }
 
+    var showAiConfigDlg by vm.showAiConfigDlgFlow.asMutableState()
+    if (showAiConfigDlg) {
+        val aiConfig = store.aiConfig
+        var protocolValue by remember { mutableStateOf(aiConfig.protocol) }
+        var apiUrlValue by remember { mutableStateOf(aiConfig.apiUrl) }
+        var apiKeyValue by remember { mutableStateOf(aiConfig.apiKey) }
+        var modelValue by remember { mutableStateOf(aiConfig.model) }
+        var temperatureValue by remember { mutableStateOf(aiConfig.temperature.toString()) }
+        var topPValue by remember { mutableStateOf(aiConfig.topP.toString()) }
+        var maxTokensValue by remember { mutableStateOf(aiConfig.maxTokens.toString()) }
+        var modelList by remember { mutableStateOf<List<String>>(emptyList()) }
+        var modelListLoading by remember { mutableStateOf(false) }
+        var modelMenuExpanded by remember { mutableStateOf(false) }
+        var testResult by remember { mutableStateOf<String?>(null) }
+        var testLoading by remember { mutableStateOf(false) }
+
+        AlertDialog(
+            properties = DialogProperties(dismissOnClickOutside = false),
+            title = { Text(text = "AI 规则设置") },
+            text = {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    // Protocol selector
+                    Text(text = "协议", style = MaterialTheme.typography.labelMedium)
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        listOf("openai", "anthropic").forEach { proto ->
+                            TextButton(
+                                onClick = { protocolValue = proto },
+                                modifier = Modifier.weight(1f),
+                                colors = if (protocolValue == proto) {
+                                    androidx.compose.material3.ButtonDefaults.textButtonColors(
+                                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                    )
+                                } else {
+                                    androidx.compose.material3.ButtonDefaults.textButtonColors()
+                                },
+                            ) {
+                                Text(
+                                    text = proto.replaceFirstChar { it.uppercase() },
+                                    color = if (protocolValue == proto) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        LocalContentColor.current
+                                    },
+                                )
+                            }
+                        }
+                    }
+
+                    CustomOutlinedTextField(
+                        label = { Text("API 地址") },
+                        value = apiUrlValue,
+                        placeholder = { Text(text = if (protocolValue == "openai") "https://api.openai.com" else "https://api.anthropic.com") },
+                        onValueChange = { apiUrlValue = it },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    CustomOutlinedTextField(
+                        label = { Text("API Key") },
+                        value = apiKeyValue,
+                        placeholder = { Text(text = "请输入 API Key") },
+                        onValueChange = { apiKeyValue = it },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        ExposedDropdownMenuBox(
+                            expanded = modelMenuExpanded,
+                            onExpandedChange = { modelMenuExpanded = it },
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            CustomOutlinedTextField(
+                                label = { Text("模型") },
+                                value = modelValue,
+                                placeholder = { Text(text = "请输入模型名称") },
+                                onValueChange = { modelValue = it; modelMenuExpanded = false },
+                                singleLine = true,
+                                modifier = Modifier.menuAnchor(),
+                                trailingIcon = {
+                                    if (modelListLoading) {
+                                        CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                                    } else if (modelList.isNotEmpty()) {
+                                        PerfIcon(imageVector = PerfIcon.UnfoldMore)
+                                    }
+                                },
+                            )
+                            ExposedDropdownMenu(
+                                expanded = modelMenuExpanded && modelList.isNotEmpty(),
+                                onDismissRequest = { modelMenuExpanded = false },
+                            ) {
+                                modelList.forEach { m ->
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                text = m,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = if (m == modelValue) MaterialTheme.colorScheme.primary else LocalContentColor.current,
+                                            )
+                                        },
+                                        onClick = {
+                                            modelValue = m
+                                            modelMenuExpanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                        PerfIconButton(
+                            imageVector = PerfIcon.Autorenew,
+                            onClick = throttle {
+                                if (apiUrlValue.isBlank() || apiKeyValue.isBlank()) {
+                                    toast("请先填写 API 地址和 Key")
+                                    return@throttle
+                                }
+                                modelListLoading = true
+                                vm.viewModelScope.launchTry {
+                                    val result = AiRuleGenerator.fetchModelList(
+                                        aiConfig.copy(
+                                            protocol = protocolValue,
+                                            apiUrl = apiUrlValue,
+                                            apiKey = apiKeyValue,
+                                            model = modelValue,
+                                        )
+                                    )
+                                    modelListLoading = false
+                                    result.onSuccess { list ->
+                                        modelList = list
+                                        if (list.isNotEmpty() && modelValue.isBlank()) {
+                                            modelValue = list.first()
+                                        }
+                                        modelMenuExpanded = list.isNotEmpty()
+                                        toast("获取到 ${list.size} 个模型")
+                                    }.onFailure { e ->
+                                        toast("获取模型列表失败：${e.message}")
+                                    }
+                                }
+                            },
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CustomOutlinedTextField(
+                            label = { Text("Temperature") },
+                            value = temperatureValue,
+                            onValueChange = { temperatureValue = it },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        )
+                        CustomOutlinedTextField(
+                            label = { Text("Top P") },
+                            value = topPValue,
+                            onValueChange = { topPValue = it },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CustomOutlinedTextField(
+                            label = { Text("Max Tokens") },
+                            value = maxTokensValue,
+                            onValueChange = { maxTokensValue = it },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    // Test button
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        TextButton(
+                            onClick = throttle {
+                                if (apiUrlValue.isBlank() || apiKeyValue.isBlank() || modelValue.isBlank()) {
+                                    toast("请先填写完整配置")
+                                    return@throttle
+                                }
+                                testLoading = true
+                                testResult = null
+                                vm.viewModelScope.launchTry {
+                                    val result = AiRuleGenerator.testConnection(
+                                        aiConfig.copy(
+                                            protocol = protocolValue,
+                                            apiUrl = apiUrlValue,
+                                            apiKey = apiKeyValue,
+                                            model = modelValue,
+                                        )
+                                    )
+                                    testLoading = false
+                                    result.onSuccess {
+                                        testResult = "连接成功"
+                                        toast("连接测试成功")
+                                    }.onFailure { e ->
+                                        testResult = "失败：${e.message}"
+                                        toast("连接测试失败：${e.message}")
+                                    }
+                                }
+                            },
+                            enabled = !testLoading,
+                        ) {
+                            if (testLoading) {
+                                CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                                Spacer(modifier = Modifier.width(4.dp))
+                            }
+                            Text(text = "测试连接")
+                        }
+                        testResult?.let {
+                            Text(
+                                text = it,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = if (it.startsWith("失败")) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.align(Alignment.CenterVertically),
+                            )
+                        }
+                    }
+                }
+            },
+            onDismissRequest = { showAiConfigDlg = false },
+            confirmButton = {
+                TextButton(onClick = throttle {
+                    val temp = temperatureValue.toFloatOrNull()
+                    val topP = topPValue.toFloatOrNull()
+                    val maxTokens = maxTokensValue.toIntOrNull()
+                    if (temp == null || topP == null || maxTokens == null) {
+                        toast("参数格式错误")
+                        return@throttle
+                    }
+                    storeFlow.update {
+                        it.copy(
+                            aiConfig = it.aiConfig.copy(
+                                protocol = protocolValue,
+                                apiUrl = apiUrlValue.trim().trimEnd('/'),
+                                apiKey = apiKeyValue.trim(),
+                                model = modelValue.trim(),
+                                temperature = temp,
+                                topP = topP,
+                                maxTokens = maxTokens,
+                            )
+                        )
+                    }
+                    toast("AI 配置已保存")
+                    showAiConfigDlg = false
+                }) {
+                    Text(text = "确认")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAiConfigDlg = false }) {
+                    Text(text = "取消")
+                }
+            },
+        )
+    }
+
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -472,6 +758,32 @@ fun AdvancedPage() {
                 subtitle = "应用界面节点信息及截图",
                 onClick = {
                     mainVm.navigatePage(SnapshotPageRoute)
+                }
+            )
+
+            TextSwitch(
+                title = "AI 规则",
+                subtitle = "保存快照后自动生成规则",
+                checked = store.aiEnable,
+                suffixIcon = {
+                    PerfCustomIconButton(
+                        size = 32.dp,
+                        iconSize = 20.dp,
+                        onClickLabel = "打开 AI 规则配置弹窗",
+                        onClick = throttle {
+                            showAiConfigDlg = true
+                        },
+                        id = R.drawable.ic_page_info,
+                        contentDescription = "AI 规则设置",
+                    )
+                },
+                onCheckedChange = {
+                    if (it && (store.aiConfig.apiUrl.isBlank() || store.aiConfig.apiKey.isBlank())) {
+                        toast("请先配置 AI 设置")
+                        showAiConfigDlg = true
+                        return@TextSwitch
+                    }
+                    storeFlow.value = store.copy(aiEnable = it)
                 }
             )
 

--- a/app/src/main/kotlin/li/songe/gkd/ui/AdvancedVm.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/AdvancedVm.kt
@@ -8,4 +8,5 @@ class AdvancedVm : ViewModel() {
     val showEditPortDlgFlow = MutableStateFlow(false)
     val showShizukuStateFlow = MutableStateFlow(false)
     val showCaptureScreenshotDlgFlow = MutableStateFlow(false)
+    val showAiConfigDlgFlow = MutableStateFlow(false)
 }

--- a/app/src/main/kotlin/li/songe/gkd/util/AiRuleGenerator.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/AiRuleGenerator.kt
@@ -1,0 +1,373 @@
+package li.songe.gkd.util
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import li.songe.gkd.app
+import li.songe.gkd.appScope
+import li.songe.gkd.data.RawSubscription
+import li.songe.gkd.store.AiConfig
+import li.songe.gkd.store.storeFlow
+import java.util.concurrent.TimeUnit
+
+@Serializable
+data class ChatMessage(
+    val role: String,
+    val content: String,
+)
+
+@Serializable
+data class ChatRequest(
+    val model: String,
+    val messages: List<ChatMessage>,
+    val temperature: Float = 0f,
+    val top_p: Float = 1f,
+    val max_tokens: Int = 4096,
+)
+
+@Serializable
+data class AnthropicMessage(
+    val role: String,
+    val content: String,
+)
+
+@Serializable
+data class AnthropicRequest(
+    val model: String,
+    val messages: List<AnthropicMessage>,
+    val temperature: Float = 0f,
+    val top_p: Float = 1f,
+    val max_tokens: Int = 4096,
+)
+
+object AiRuleGenerator {
+
+    val isGenerating = MutableStateFlow(false)
+    val pendingCount = MutableStateFlow(0)
+
+    private val taskQueue = Channel<Long>(Channel.UNLIMITED)
+
+    init {
+        appScope.launchTry {
+            for (snapshotId in taskQueue) {
+                processRule(snapshotId)
+            }
+        }
+    }
+
+    private var cachedPrompt: String? = null
+
+    private suspend fun loadPrompt(): String = withContext(Dispatchers.IO) {
+        cachedPrompt?.let { return@withContext it }
+        val text = app.assets.open("gkd-rule-generator-prompt.md").bufferedReader().readText()
+        cachedPrompt = text
+        text
+    }
+
+    fun fixApiUrl(url: String, protocol: String): String {
+        var fixed = url.trim().trimEnd('/')
+        // If URL already contains a full path, don't modify
+        if (fixed.contains("/chat/completions") || fixed.contains("/messages")) {
+            return fixed
+        }
+        // If URL already ends with /v1, keep it
+        if (fixed.endsWith("/v1")) {
+            return fixed
+        }
+        // If URL already contains /v1 somewhere, don't add it again
+        if (fixed.contains("/v1/")) {
+            return fixed
+        }
+        return "$fixed/v1"
+    }
+
+    private fun buildApiEndpoint(config: AiConfig): String {
+        val baseUrl = fixApiUrl(config.apiUrl, config.protocol)
+        return when (config.protocol) {
+            "anthropic" -> "$baseUrl/messages"
+            else -> "$baseUrl/chat/completions"
+        }
+    }
+
+    private fun createHttpClient(): HttpClient {
+        return HttpClient(OkHttp) {
+            engine {
+                config {
+                    connectTimeout(30, TimeUnit.SECONDS)
+                    readTimeout(0, TimeUnit.SECONDS) // no timeout for AI response
+                    writeTimeout(30, TimeUnit.SECONDS)
+                }
+            }
+        }
+    }
+
+    private fun buildRequestBody(config: AiConfig, content: String, maxTokensOverride: Int? = null): String {
+        val maxTokens = maxTokensOverride ?: config.maxTokens
+        return when (config.protocol) {
+            "anthropic" -> json.encodeToString(
+                AnthropicRequest(
+                    model = config.model,
+                    messages = listOf(AnthropicMessage("user", content)),
+                    temperature = config.temperature,
+                    top_p = config.topP,
+                    max_tokens = maxTokens,
+                )
+            )
+            else -> json.encodeToString(
+                ChatRequest(
+                    model = config.model,
+                    messages = listOf(ChatMessage("user", content)),
+                    temperature = config.temperature,
+                    top_p = config.topP,
+                    max_tokens = maxTokens,
+                )
+            )
+        }
+    }
+
+    suspend fun testConnection(config: AiConfig): Result<String> = runCatching {
+        val httpClient = createHttpClient()
+        try {
+            val endpoint = buildApiEndpoint(config)
+            val response = httpClient.post(endpoint) {
+                when (config.protocol) {
+                    "anthropic" -> {
+                        header("x-api-key", config.apiKey)
+                        header("anthropic-version", "2023-06-01")
+                    }
+                    else -> header("Authorization", "Bearer ${config.apiKey}")
+                }
+                contentType(ContentType.Application.Json)
+                setBody(buildRequestBody(config, "hi", maxTokensOverride = 1))
+            }
+            response.bodyAsText()
+        } finally {
+            httpClient.close()
+        }
+    }
+
+    suspend fun fetchModelList(config: AiConfig): Result<List<String>> = runCatching {
+        val baseUrl = fixApiUrl(config.apiUrl, config.protocol)
+        val modelsEndpoint = "$baseUrl/models"
+        val httpClient = createHttpClient()
+        try {
+            val response = httpClient.get(modelsEndpoint) {
+                when (config.protocol) {
+                    "anthropic" -> {
+                        header("x-api-key", config.apiKey)
+                        header("anthropic-version", "2023-06-01")
+                    }
+                    else -> header("Authorization", "Bearer ${config.apiKey}")
+                }
+            }
+            val body = response.bodyAsText()
+            val jsonElement = json.parseToJsonElement(body)
+            val data = jsonElement.jsonObject["data"]
+                ?: throw Exception("No data field in response")
+            data.jsonArray.mapNotNull { element ->
+                try {
+                    element.jsonObject["id"]?.jsonPrimitive?.content
+                } catch (_: Exception) {
+                    null
+                }
+            }
+        } finally {
+            httpClient.close()
+        }
+    }
+
+    suspend fun generateRule(snapshotId: Long) {
+        val config = storeFlow.value.aiConfig
+        if (config.apiUrl.isBlank() || config.apiKey.isBlank() || config.model.isBlank()) {
+            toast("请先配置 AI 规则设置")
+            return
+        }
+        pendingCount.value++
+        taskQueue.send(snapshotId)
+        if (isGenerating.value) {
+            toast("AI 任务已加入队列（排队中：${pendingCount.value}）")
+        }
+    }
+
+    private suspend fun processRule(snapshotId: Long) {
+        val config = storeFlow.value.aiConfig
+        isGenerating.value = true
+        try {
+            toast("AI 正在生成规则...", forced = true)
+            val prompt = loadPrompt()
+            val snapshotJson = withContext(Dispatchers.IO) {
+                SnapshotExt.snapshotFile(snapshotId).readText()
+            }
+            val userContent = "$prompt\n$snapshotJson"
+            LogUtils.d("AI generateRule: prompt length=${prompt.length}, snapshot length=${snapshotJson.length}, total=${userContent.length}")
+
+            val result = callAiApi(config, userContent)
+            LogUtils.d("AI extracted content (first 2000 chars): ${result.take(2000)}")
+            val ruleText = extractContent(result)
+            LogUtils.d("AI after extractContent (first 2000 chars): ${ruleText.take(2000)}")
+
+            val parsed = parseAndValidateRule(ruleText)
+            if (parsed == null) {
+                toast("AI 生成的规则 JSON 不合法，重试中...")
+                val retryResult = callAiApi(config, userContent)
+                val retryText = extractContent(retryResult)
+                val retryParsed = parseAndValidateRule(retryText)
+                if (retryParsed == null) {
+                    toast("AI 生成规则失败：JSON 解析错误")
+                    return
+                }
+                insertRuleToSubscription(retryParsed)
+            } else {
+                insertRuleToSubscription(parsed)
+            }
+            toast("AI 规则生成成功并已添加到本地规则")
+        } catch (e: Exception) {
+            toast("AI 生成规则失败：${e.message}")
+            LogUtils.d("AI rule generation failed", e)
+        } finally {
+            pendingCount.value--
+            isGenerating.value = pendingCount.value > 0
+        }
+    }
+
+    private suspend fun callAiApi(config: AiConfig, userContent: String): String {
+        val endpoint = buildApiEndpoint(config)
+        val requestBody = buildRequestBody(config, userContent)
+        LogUtils.d("AI Request endpoint: $endpoint")
+        LogUtils.d("AI Request body (first 2000 chars): ${requestBody.take(2000)}")
+        val httpClient = createHttpClient()
+        try {
+            val response = httpClient.post(endpoint) {
+                when (config.protocol) {
+                    "anthropic" -> {
+                        header("x-api-key", config.apiKey)
+                        header("anthropic-version", "2023-06-01")
+                    }
+                    else -> header("Authorization", "Bearer ${config.apiKey}")
+                }
+                contentType(ContentType.Application.Json)
+                setBody(requestBody)
+            }
+            val body = response.bodyAsText()
+            LogUtils.d("AI Response (first 3000 chars): ${body.take(3000)}")
+            val jsonElement = json.parseToJsonElement(body)
+
+            return when (config.protocol) {
+                "anthropic" -> {
+                    val contentArr = jsonElement.jsonObject["content"]
+                        ?: throw Exception("No content in Anthropic response")
+                    contentArr.jsonArray.firstOrNull()?.jsonObject?.get("text")?.jsonPrimitive?.content
+                        ?: throw Exception("No text in Anthropic content")
+                }
+                else -> {
+                    val choices = jsonElement.jsonObject["choices"]
+                        ?: throw Exception("No choices in OpenAI response")
+                    choices.jsonArray.firstOrNull()?.jsonObject?.get("message")?.jsonObject?.get("content")?.jsonPrimitive?.content
+                        ?: throw Exception("No content in OpenAI response")
+                }
+            }
+        } finally {
+            httpClient.close()
+        }
+    }
+
+    private fun extractContent(text: String): String {
+        var content = text.trim()
+        // Try to extract JSON from markdown code block anywhere in the text
+        val codeBlockRegex = Regex("```(?:json5?)?\\s*\\n?([\\s\\S]*?)\\n?```")
+        val match = codeBlockRegex.find(content)
+        if (match != null) {
+            content = match.groupValues[1].trim()
+        } else {
+            // Remove markdown code block markers at start/end
+            if (content.startsWith("```json5") || content.startsWith("```json") || content.startsWith("```")) {
+                content = content.removePrefix("```json5").removePrefix("```json").removePrefix("```")
+            }
+            if (content.endsWith("```")) {
+                content = content.removeSuffix("```")
+            }
+            content = content.trim()
+        }
+        // If content doesn't start with '{', try to find the first '{' and last '}'
+        if (!content.startsWith("{")) {
+            val firstBrace = content.indexOf('{')
+            val lastBrace = content.lastIndexOf('}')
+            if (firstBrace >= 0 && lastBrace > firstBrace) {
+                content = content.substring(firstBrace, lastBrace + 1)
+            }
+        }
+        return content
+    }
+
+    private fun parseAndValidateRule(text: String): RawSubscription? {
+        // First try parsing as full subscription
+        try {
+            return RawSubscription.parse(text, json5 = true)
+        } catch (_: Exception) {}
+        try {
+            return RawSubscription.parse(text, json5 = false)
+        } catch (_: Exception) {}
+
+        // AI typically outputs an App-level JSON (id=packageName, groups=[...])
+        // Wrap it into a subscription structure
+        try {
+            val jsonElement = json.parseToJsonElement(text)
+            val app = RawSubscription.parseApp(jsonElement.jsonObject)
+            LogUtils.d("AI parsed as RawApp: id=${app.id}, groups=${app.groups.size}")
+            // Build a minimal subscription containing this app
+            return RawSubscription(
+                id = -1L,
+                name = "AI Generated",
+                version = 1,
+                apps = listOf(app),
+            )
+        } catch (e: Exception) {
+            LogUtils.d("AI parse as app failed: ${e.message}")
+            LogUtils.d("AI failed text (first 500 chars): ${text.take(500)}")
+            return null
+        }
+    }
+
+    private fun insertRuleToSubscription(newSubs: RawSubscription) {
+        val currentSubs = subsMapFlow.value[LOCAL_SUBS_ID] ?: return
+        val newApp = newSubs.apps.firstOrNull() ?: return
+        val existingApp = currentSubs.apps.find { it.id == newApp.id }
+
+        // Reassign group keys to avoid conflicts with existing groups
+        val existingKeys = existingApp?.groups?.map { it.key }?.toSet() ?: emptySet()
+        var nextKey = (existingKeys.maxOrNull() ?: -1) + 1
+        val fixedGroups = newApp.groups.map { group ->
+            val newKey = nextKey++
+            group.copy(key = newKey)
+        }
+        val fixedApp = newApp.copy(groups = fixedGroups)
+
+        val updatedSubs = if (existingApp != null) {
+            val updatedApp = existingApp.copy(
+                groups = existingApp.groups + fixedGroups
+            )
+            currentSubs.copy(
+                apps = currentSubs.apps.map { if (it.id == updatedApp.id) updatedApp else it }
+            )
+        } else {
+            currentSubs.copy(
+                apps = (currentSubs.apps + fixedApp).filterIfNotAll { it.groups.isNotEmpty() }
+            )
+        }
+        updateSubscription(updatedSubs)
+    }
+}

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.JsonObject
 import li.songe.gkd.a11y.A11yRuleEngine
 import li.songe.gkd.a11y.TopActivity
 import li.songe.gkd.a11y.topActivityFlow
+import li.songe.gkd.appScope
 import li.songe.gkd.data.ComplexSnapshot
 import li.songe.gkd.data.RpcError
 import li.songe.gkd.data.info2nodeList
@@ -286,6 +287,11 @@ object SnapshotExt {
             toast(tip, forced = true)
             val desc = snapshot.appInfo?.name ?: snapshot.appId
             snapshotNotif.copy(text = "快照「$desc」已保存至记录").notifySelf()
+            if (storeFlow.value.aiEnable) {
+                appScope.launchTry {
+                    AiRuleGenerator.generateRule(snapshot.id)
+                }
+            }
             return snapshot
         } finally {
             captureLoading.value = false


### PR DESCRIPTION
## AI 自动规则生成

为 GKD 添加基于大模型的自动订阅规则生成能力。快照保存后自动调用 AI 生成匹配规则，并写入本地订阅。

### 功能

- 快照保存后自动触发规则生成
- 支持 OpenAI / Anthropic 协议
- 支持模型列表拉取与连接测试
- 生成结果自动写入本地订阅，启用即生效

### 使用

设置 → 高级设置 → 开启 AI 规则并配置大模型。此后每次捕获快照会自动生成规则并加入本地订阅。

### 改动文件

| 文件 | 说明 |
|------|------|
| `store/SettingsStore.kt` | 新增 AiConfig 数据类 |
| `ui/AdvancedPage.kt` | AI 配置对话框 UI |
| `ui/AdvancedVm.kt` | 对话框状态管理 |
| `util/AiRuleGenerator.kt` | AI 调用、JSON 解析与规则插入 |
| `util/SnapshotExt.kt` | 快照保存后触发生成 |
| `assets/gkd-rule-generator-prompt.md` | 内置 prompt |