### PR TITLE
fix(a11y): 修复 Switch 开关状态 TalkBack 朗读不正确

### DIFF
--- a/app/src/main/kotlin/li/songe/gkd/ui/component/InnerDisableSwitch.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/component/InnerDisableSwitch.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.stateDescription
 import li.songe.gkd.ui.share.LocalMainViewModel
 import li.songe.gkd.util.throttle
@@ -36,8 +36,9 @@ fun InnerDisableSwitch(
         checked = false,
         enabled = false,
         onCheckedChange = null,
-        modifier = modifier.semantics {
+        modifier = modifier.clearAndSetSemantics {
             stateDescription = "已禁用"
+            role = Role.Switch
         }
             .minimumInteractiveComponentSize().run {
                 if (isSelectedMode) {

--- a/app/src/main/kotlin/li/songe/gkd/ui/component/PerfSwitch.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/component/PerfSwitch.kt
@@ -6,7 +6,8 @@ import androidx.compose.material3.SwitchColors
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.stateDescription
 import li.songe.gkd.util.throttle
 
@@ -24,8 +25,9 @@ fun PerfSwitch(
     Switch(
         checked = checked,
         onCheckedChange = onCheckedChange?.let { throttle(it) },
-        modifier = modifier.semantics {
+        modifier = modifier.clearAndSetSemantics {
             stateDescription = if (checked) "已开启" else "已关闭"
+            role = Role.Switch
         },
         thumbContent = thumbContent,
         enabled = enabled,

--- a/app/src/main/kotlin/li/songe/gkd/ui/component/TextSwitch.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/component/TextSwitch.kt
@@ -90,9 +90,6 @@ fun TextSwitch(
             checked = checked,
             enabled = enabled,
             onCheckedChange = onCheckedChange?.let { throttle(fn = it) },
-            modifier = Modifier.semantics {
-                this.stateDescription = title + if (checked) "已开启" else "已关闭"
-            }
         )
     }
 }

--- a/app/src/main/kotlin/li/songe/gkd/ui/component/TriStateSwitch.kt
+++ b/app/src/main/kotlin/li/songe/gkd/ui/component/TriStateSwitch.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.invalidateMeasurement
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
@@ -664,10 +666,18 @@ fun PerfTriStateSwitch(
     colors: TriStateSwitchColors = TriStateSwitchDefaults.colors(),
     interactionSource: MutableInteractionSource? = null,
 ) = androidx.compose.runtime.key(key) {
+    val stateDesc = when (checked) {
+        true -> "已开启"
+        false -> "已关闭"
+        null -> "未设置"
+    }
     TriStateSwitch(
         checked = checked,
         onCheckedChange = onCheckedChange,
-        modifier = modifier,
+        modifier = modifier.clearAndSetSemantics {
+            stateDescription = stateDesc
+            role = Role.Switch
+        },
         thumbContent = thumbContent,
         enabled = enabled,
         colors = colors,


### PR DESCRIPTION
## 问题
TalkBack 用户点击 Switch 开关后，无法正确获知状态变化：
- 点击已关闭的开关，状态变为已开启，但 TalkBack 仍朗读"已关闭, Switch"
- 原因：`modifier.semantics { stateDescription }` 设置的状态描述与 Switch 内部 `toggleable` modifier 的默认语义冲突，导致状态描述被覆盖或时机不对

## 修复
- **PerfSwitch**: `semantics` → `clearAndSetSemantics`，清除 Switch 内部默认的 On/Off 语义，确保 TalkBack 只读到中文状态描述；添加 `role = Role.Switch`
- **InnerDisableSwitch**: 同上，"已禁用" 状态同理修复
- **PerfTriStateSwitch**: 新增 `clearAndSetSemantics`，三态开关朗读"已开启"/"未设置"/"已关闭"
- **TextSwitch**: 移除传给 PerfSwitch 的外部 `Modifier.semantics { stateDescription }` 覆盖，避免语义冲突

## 测试
- 开启 TalkBack，点击任意 Switch 开关
- 验证点击后朗读的状态与视觉状态一致