### PR TITLE
perf: Optimize snapshot storage with WebP lossy compression

### DIFF
--- a/app/src/main/kotlin/li/songe/gkd/util/ImageUtils.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/ImageUtils.kt
@@ -20,8 +20,8 @@ import java.io.OutputStream
 object ImageUtils {
     fun save2Album(
         src: Bitmap,
-        quality: Int = 100,
-        format: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG,
+        quality: Int = 85,
+        format: Bitmap.CompressFormat = Bitmap.CompressFormat.WEBP,
         recycle: Boolean = true,
     ): Boolean {
         val safeDirName = app.packageName

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -56,8 +56,17 @@ object SnapshotExt {
         }
     }
 
-    fun screenshotFile(id: Long) = snapshotParentPath(id).resolve("${id}.webp")
+    fun screenshotFile(id: Long): File {
+        val webp = snapshotParentPath(id).resolve("${id}.webp")
+        // 存在webp优先返回；不存在则返回旧png文件
+        if (webp.exists()) return webp
+        return snapshotParentPath(id).resolve("${id}.png")
+    }
 
+    // 仅在[保存新快照]时调用，强制输出webp，不要在读取逻辑使用
+    private fun newScreenshotOutputFile(id: Long): File {
+        return snapshotParentPath(id).resolve("${id}.webp")
+    }
     suspend fun snapshotZipFile(
         snapshotId: Long,
         appId: String? = null,
@@ -265,7 +274,7 @@ object SnapshotExt {
             val (bitmap, currentStatus) = screenResult // 拆开(图片+状态)
             withContext(Dispatchers.IO) {
                 snapshotParentPath(snapshot.id).autoMk()
-                screenshotFile(snapshot.id).outputStream().use { stream ->
+                newScreenshotOutputFile(snapshot.id).outputStream().use { stream ->
                     bitmap.compress(Bitmap.CompressFormat.WEBP, 85, stream)
                 }
                 snapshotFile(snapshot.id).writeText(keepNullJson.encodeToString(snapshot))

--- a/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
+++ b/app/src/main/kotlin/li/songe/gkd/util/SnapshotExt.kt
@@ -56,7 +56,7 @@ object SnapshotExt {
         }
     }
 
-    fun screenshotFile(id: Long) = snapshotParentPath(id).resolve("${id}.png")
+    fun screenshotFile(id: Long) = snapshotParentPath(id).resolve("${id}.webp")
 
     suspend fun snapshotZipFile(
         snapshotId: Long,
@@ -266,7 +266,7 @@ object SnapshotExt {
             withContext(Dispatchers.IO) {
                 snapshotParentPath(snapshot.id).autoMk()
                 screenshotFile(snapshot.id).outputStream().use { stream ->
-                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                    bitmap.compress(Bitmap.CompressFormat.WEBP, 85, stream)
                 }
                 snapshotFile(snapshot.id).writeText(keepNullJson.encodeToString(snapshot))
                 minSnapshotFile(snapshot.id).writeText(


### PR DESCRIPTION
- 将快照截图文件后缀从 png 更改为 WebP
- 以 WebP 格式压缩截图（质量=85）
- [保存截图到相册] 的格式也改为 WebP

有损 WebP 会丢失部分色彩信息，但日常截图几乎感知不到，
相较于png格式，体积小很多，网络快照可以有更快的加载速度。
至于压缩质量，快照截图是用于界面元素定位、看控件文字，不是搞修图摄影，质量85也够了。

下面是不同格式的快照截图对比：

<div align="center">
  <table border="0">
    <tr>
      <td align="center" style="border: none; padding: 10px;">
        <img src="https://github.com/user-attachments/assets/d525893f-7298-457b-b80a-c09ca2186608" width="100%" style="max-width: 350px; display: block;" />
      </td>
      <td align="center" style="border: none; padding: 10px;">
        <img src="https://github.com/user-attachments/assets/9ca98f7e-512a-4a39-aba5-837072cfc3ec" width="100%" style="max-width: 350px; display: block;" />
      </td>
    </tr>
  </table>
</div>

---

已测试：

- [x] 截取快照
- [x] 保存(快照)到下载
- [x] 保存截图到相册  （能正常导出 WebP 格式图片）
- [x] 替换截图 （编辑完并保存后图片后缀变为 `.jpg` ，回到 GKD 替换截图后图片后缀又变为 `.webp` ）
- [x] 生成链接 （ https://i.gkd.li/i/29993180 ，直接访问会提示[快照数据缺失]，需要改版的快照审查工具才能访问）
- [x] 用via浏览器打开http设备里的快照  （图片正常显示）
- [x] (PC端)打开http设备里的快照  （图片正常显示）
- [x] (PC端)生成链接-快照 （ https://i.gkd.li/i/29900743 ）
- [x] (PC端)生成链接-图片 （ https://e.gkd.li/9a7ef36f-5806-450b-b49a-933f1474dce0 ）

待解决的问题：

- [x] [快照审查页](https://i.gkd.li)能直接打开 http 调试设备里的快照，但是无法导入 其内截图是WebP格式的快照，例如 
[相册_InternalPhotoPageActivity-1783707475601.zip](https://github.com/user-attachments/files/29901799/_InternalPhotoPageActivity-1783707475601.zip)。 （[inspect #68](https://github.com/gkd-kit/inspect/pull/68) 已修）
- [x] 在GKD上无法处理旧的png快照，例如 查看、保存到下载、保存截图到相册 等操作。 （[944b47a](https://github.com/gkd-kit/gkd/pull/1412/changes/944b47a9661ad79c235204973e7780ab12e972c2) 已修）
