### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/Build-Apk.yml
+++ b/.github/workflows/Build-Apk.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '21'

--- a/.github/workflows/Build-Release.yml
+++ b/.github/workflows/Build-Release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '21'


### PR DESCRIPTION
## Summary

Upgrade both active GitHub workflow references from `actions/setup-java@v5` to `@v6`.

## Validation

- `git diff --check`
- Verified no setup-java references older than v6 remain in active workflows
