### PR TITLE
fix(a11y): 兼容桌面内容变化事件触发订阅自动更新

### DIFF
--- a/gkd-app/src/main/kotlin/li/gkd/app/a11y/A11yFeat.kt
+++ b/gkd-app/src/main/kotlin/li/gkd/app/a11y/A11yFeat.kt
@@ -30,10 +30,23 @@ import li.gkd.selector.NodeAdapter
 fun onA11yFeatEvent(event: AccessibilityEvent) = event.run {
     if (event.eventType == STATE_CHANGED) {
         watchCaptureScreenshot()
-        if (event.packageName == launcherAppId) {
-            watchAutoUpdateSubs()
-        }
     }
+    if (isLauncherAutoUpdateEvent(event.eventType, event.packageName, launcherAppId)) {
+        watchAutoUpdateSubs()
+    }
+}
+
+fun isLauncherAutoUpdateEvent(
+    eventType: Int,
+    packageName: CharSequence?,
+    launcherAppId: String,
+): Boolean {
+    if (
+        eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED &&
+        eventType != AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+    ) return false
+    return launcherAppId.isNotEmpty() &&
+            packageName?.contentEquals(launcherAppId) == true
 }
 
 private var tempEventSelector = "" to (null as Selector?)

--- a/gkd-app/src/test/kotlin/li/gkd/app/a11y/AutoUpdateTriggerTest.kt
+++ b/gkd-app/src/test/kotlin/li/gkd/app/a11y/AutoUpdateTriggerTest.kt
@@ -1,0 +1,65 @@
+package li.gkd.app.a11y
+
+import android.view.accessibility.AccessibilityEvent
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoUpdateTriggerTest {
+    private val launcherAppId = "com.miui.home"
+
+    @Test
+    fun acceptsLauncherStateAndContentEvents() {
+        assertTrue(
+            isLauncherAutoUpdateEvent(
+                AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+                launcherAppId,
+                launcherAppId,
+            )
+        )
+        assertTrue(
+            isLauncherAutoUpdateEvent(
+                AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+                launcherAppId,
+                launcherAppId,
+            )
+        )
+    }
+
+    @Test
+    fun comparesPackageNamesByText() {
+        val packageName: CharSequence = StringBuilder(launcherAppId)
+        assertTrue(
+            isLauncherAutoUpdateEvent(
+                AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+                packageName,
+                launcherAppId,
+            )
+        )
+    }
+
+    @Test
+    fun rejectsOtherEventsAndPackages() {
+        assertFalse(
+            isLauncherAutoUpdateEvent(
+                AccessibilityEvent.TYPE_VIEW_CLICKED,
+                launcherAppId,
+                launcherAppId,
+            )
+        )
+        assertFalse(
+            isLauncherAutoUpdateEvent(
+                AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+                "com.example.other",
+                launcherAppId,
+            )
+        )
+        assertFalse(
+            isLauncherAutoUpdateEvent(
+                AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+                launcherAppId,
+                "",
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 问题

订阅自动更新目前只在默认桌面发送 `TYPE_WINDOW_STATE_CHANGED` 时触发。部分 HyperOS/MIUI 设备返回桌面时只发送 `TYPE_WINDOW_CONTENT_CHANGED`，导致开启自动更新后也不会执行检查。

## 修复

- 保留原有的 `TYPE_WINDOW_STATE_CHANGED` 触发，并支持默认桌面的 `TYPE_WINDOW_CONTENT_CHANGED`。
- 先过滤事件类型，再匹配默认桌面包名。
- 自动截图功能仍然只响应 `TYPE_WINDOW_STATE_CHANGED`，不会因新增内容变化事件而扩大触发范围。

## 测试

- 单元测试覆盖原有状态变化事件、新增内容变化事件，以及其他事件类型和应用包名。
- 在红米k90真机上验证，返回桌面能够触发自动检查，并完成订阅从 v578 到 v579 的更新。
<img width="1179" height="867" alt="image" src="https://raw.githubusercontent.com/eviaaaaa/gkd/pr-assets/gkd-auto-update-trigger.png" />
注：之前15天都没有自动更新，订阅停留在v565，直到我手动触发更新到v578
